### PR TITLE
Fixed indented tasks indentation.

### DIFF
--- a/SCSS/ITS Theme/_Lists - Checkboxes.scss
+++ b/SCSS/ITS Theme/_Lists - Checkboxes.scss
@@ -23,6 +23,7 @@ li.task-list-item {
     vertical-align: 1px;
     margin-left: 0px;
     margin-right: 10px;
+    line-indent: inherit !important;
 }
 
 /*Checkbox Checked color*/


### PR DESCRIPTION
This is not the most ideal solution, I could not find where this `line-indent: -1.5em` is coming from.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/1845147/160301118-dadfb10b-0f3e-4353-b1b8-129b429df348.png">

This is why the line needs important:
<img width="327" alt="image" src="https://user-images.githubusercontent.com/1845147/160301191-1e8afa95-2dfb-4599-af60-685e245ed4f4.png">

Fixes #95