### PR TITLE
[WOTC/WOTC-Beyond] Box shadow empty state with no obsidian files open

### DIFF
--- a/Theme - All Alternate Themes.css
+++ b/Theme - All Alternate Themes.css
@@ -1024,7 +1024,9 @@ settings:
 .wotc-beyond .workspace-drawer-inner,
 .wotc-beyond .modal,
 .wotc-beyond .community-plugin-search,
-.wotc-beyond .prompt {
+.wotc-beyond .prompt,
+.wotc .workspace-leaf-content[data-type=empty] .view-content,
+.wotc-beyond .workspace-leaf-content[data-type=empty] .view-content {
   box-shadow: 0 0 60px var(--outline) inset;
 }
 .paper .workspace-tabs, .paper .modal.mod-settings .vertical-tab-header,
@@ -1054,7 +1056,9 @@ settings:
 .wotc-beyond .horizontal-tab-content,
 .wotc-beyond .vertical-tab-content,
 .wotc-beyond .horizontal-tab-nav-item:not(.is-active),
-.wotc-beyond .vertical-tab-nav-item:not(.is-active) {
+.wotc-beyond .vertical-tab-nav-item:not(.is-active),
+.wotc .workspace-leaf-content[data-type=empty] .empty-state-container,
+.wotc-beyond .workspace-leaf-content[data-type=empty] .empty-state-container {
   background: transparent;
 }
 


### PR DESCRIPTION
Update: Obsidian v0.15.9 shows an empty state when no files are open (which doesn't look good, plain white background without the WOTC/WOTC/Beyond burnt paper edges gradient)

This PR fixes the look of the empty state