### PR TITLE
Fixed popover custom image sizing

### DIFF
--- a/SCSS/ITS Theme/_Popover.scss
+++ b/SCSS/ITS Theme/_Popover.scss
@@ -21,9 +21,8 @@
 }
 
 /*Fit image in popover*/
-.popover.hover-popover img:not([alt=""]):not(.cm-widgetBuffer):not(.emoji):not(.link-favicon):not([width]) {
+.popover.hover-popover img:not([alt=""]):not(.cm-widgetBuffer):not(.emoji):not(.link-favicon) {
     max-width: 100%;
-    width: 100%;
     object-fit: cover;
 }
 .popover.hover-popover img[alt] {

--- a/SCSS/ITS Theme/_Popover.scss
+++ b/SCSS/ITS Theme/_Popover.scss
@@ -21,7 +21,7 @@
 }
 
 /*Fit image in popover*/
-.popover.hover-popover img:not([alt=""]):not(.cm-widgetBuffer):not(.emoji):not(.link-favicon) {
+.popover.hover-popover img:not([alt=""]):not(.cm-widgetBuffer):not(.emoji):not(.link-favicon):not([width]) {
     max-width: 100%;
     width: 100%;
     object-fit: cover;


### PR DESCRIPTION
Fixes #182 by making popover images not set fit the max width. This will make [built-in image sizing](https://help.obsidian.md/Linking+notes+and+files/Embedding+files#Embed+an+image+in+a+note) work for resizing images smaller than the popover but not overflow the 100% width.

Markup used to test (replace with your own images):

```md
Small image

![[leaf-on-log.png|100]]

Big image

![[moss-branch.png|800]]

Regular image

![[sky-train.png]]
```

## Original

https://user-images.githubusercontent.com/109556932/236649305-c7d17911-2cc1-4675-bf46-fc5e062952ee.mp4

## Fixed

https://user-images.githubusercontent.com/109556932/236649270-a0fc6f9c-8d86-4cc6-9207-a085328291ee.mp4
