### PR TITLE
Updating line spacing in Theme.css

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2977,7 +2977,7 @@ body.theme-light {
   --icon-s: 16px;
   --icon-m: 17px;
   --icon-l: 18px;
-  --line-height-tight: 1.3em;
+  --line-height-tight: normal;
   --scroll-size: 7px;
   --divider-width: 2px;
   --divider-width-hover: 5px;


### PR DESCRIPTION
In line 2980 of the code, the command "--line-height-tight" that is set to 1.3 em, causes the letters of the titles for boxes of the notes in canvas (when doing the action to move away to have a complete vision of the job), these are pasted when they make a line break for the same size of the box in case it is small or if the title is too long, so to "solve more or less" this problem, change the value of the command to "normal".

![image](https://github.com/SlRvb/Obsidian--ITS-Theme/assets/126630420/4ac932ed-bd9d-411d-a143-5a6fda499c83)

![image](https://github.com/SlRvb/Obsidian--ITS-Theme/assets/126630420/0f7153a7-14ce-4eba-86a3-86fd5c2a69f6)
