### PR TITLE
Refactored callouts using maps, loops, placeholders, and mixins

### DIFF
--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-adjustments.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-adjustments.scss
@@ -1,28 +1,26 @@
+@use "utils";
 
-// No Title
-.callout.callout.callout.callout:is(
-    [data-callout-metadata~="no-t"], 
-    [data-callout-metadata~="no-title"]
-) > .callout-title { display: none; }
+@include utils.select-by-callout-metadata(4, "no-t", "no-title") {
+    & > .callout-title {
+        display: none;
+    }
+}
 
-// Show Title
-.callout.callout.callout.callout:is(
-    [data-callout-metadata~="s-t"], 
-    [data-callout-metadata~="show-title"]
-) {
-    & > .callout-title { display: flex; }
-    
-    & > .callout-content > p { margin-top: 0; }
-} 
-// Subtitle
-.callout.callout.callout.callout:is(
-    [data-callout-metadata~="subtitle"], 
-    [data-callout-metadata~="subt"]
-) {
+@include utils.select-by-callout-metadata(4, "s-t", "show-title") {
+    & > .callout-title {
+        display: flex;
+    }
+
+    & > .callout-content > p {
+        margin-top: 0;
+    }
+}
+
+@include utils.select-by-callout-metadata(4, "subtitle", "subt") {
     & .callout-title {
         align-content: center;
         align-items: center;
-        
+
         & em {
             display: block;
             font-style: normal;
@@ -38,58 +36,57 @@
     }
 }
 
-
-
 // No Icon
-.callout.callout:is(
-    [data-callout-metadata~="no-i"], 
-    [data-callout-metadata~="no-icon"]
-) > .callout-title > .callout-icon { 
-    width: 0; height: 0; 
-    --icon-size: 0;
+@include utils.select-by-callout-metadata(2, "no-i", "no-icon") {
+    & > .callout-title > .callout-icon {
+        width: 0;
+        height: 0;
+        --icon-size: 0;
+    }
 } // For Export
 
-
-
 //No Table Header
-.callout:is(
-    [data-callout-metadata~="n-th"], 
-    [data-callout-metadata~="no-table-header"]
-) > .callout-content {
-    & table { 
-        margin-bottom: 5px; 
-        
+
+@include utils.select-by-callout-metadata(1, "n-th", "no-table-header") {
+    & .callout-content table {
+        margin-bottom: 5px;
+
         & thead,
-        & th { display: none; }
+        & th {
+            display: none;
+        }
     }
 }
+
 //Wide Table
-.callout:is(
-    [data-callout-metadata~="t-w"], 
-    [data-callout-metadata~="table-wide"]
-) {
-    & table { 
-        width: 100%; 
-        
-        & td { width: calc(var(--tbl-w) / 2); }
+@include utils.select-by-callout-metadata(1, "t-w", "table-wide") {
+    & table {
+        width: 100%;
+
+        & td {
+            width: calc(var(--tbl-w) / 2);
+        }
     }
-} 
-//Table Text Alignment
-.callout[data-callout-metadata~="table-cell-top"] table td 
-{ vertical-align: top; }
-//Table Margins
-.callout.callout:is(
-    [data-callout-metadata~=t-nmg],
-    [data-callout-metadata~=table-no-margin]
-) table {
-    margin-block-start: 0;
-    margin-block-end: 0;
 }
+//Table Text Alignment
 
+@include utils.select-by-callout-metadata(1, "table-cell-top") {
+    & table td {
+        vertical-align: top;
+    }
+}
+//Table Margins
 
+@include utils.select-by-callout-metadata(2, "t-nmg", "table-no-margin") {
+    & table {
+        margin-block-start: 0;
+        margin-block-end: 0;
+    }
+}
 
 //Expand for Embed
-.callout[data-callout-metadata~="embed"] {
+
+@include utils.select-by-callout-metadata(1, "embed") {
     & .callout-content,
     & > .callout-content > p {
         margin: 0;
@@ -97,25 +94,22 @@
     }
 }
 
-
-
-
 //Collapse
-.callout[data-callout-metadata~="collapse"] * {
-    margin: 0 !important;
-    padding: 0 !important;
-    grid-gap: 0 !important;
+@include utils.select-by-callout-metadata(1, "collapse") {
+    & * {
+        margin: 0 !important;
+        padding: 0 !important;
+        grid-gap: 0 !important;
+    }
 }
 
 //Borderless
-.callout.callout.callout:is(
-    [data-callout-metadata~="nbrd"], 
-    [data-callout-metadata~="no-border"]
-) { border: 0; }
+@include utils.select-by-callout-metadata(3, "nbrd", "no-border") {
+    border: 0;
+}
 
 //Clean
-.callout.callout.callout[data-callout-metadata~="clean"],
-.callout.callout.callout[data-callout-metadata~="clean"] > .callout-content {
+@include utils.select-by-callout-metadata(3, "clean") {
     border: 0;
     box-shadow: none;
     --callout-color: transparent;
@@ -127,7 +121,11 @@
 }
 
 //Clear
-.callout[data-callout-metadata~="clear"] { clear: both; }
+@include utils.select-by-callout-metadata(1, "clear") {
+    clear: both;
+}
 
 //Fix iframe Code
-.callout #vid { text-align: left; }
+.callout #vid {
+    text-align: left;
+}

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-coloring.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-coloring.scss
@@ -1,6 +1,7 @@
+@use "utils";
+@use "sass:string";
 
-/*--Callout Coloring--*/
-.callout.callout.callout {
+@include utils.repeat-selector(".callout", 3) {
     --callout-blue: 82, 139, 212;
     --callout-green: 86, 179, 117;
     --callout-orange: 230, 129, 63;
@@ -12,185 +13,36 @@
     --callout-brown: 161, 106, 73;
     --callout-black: 0, 0, 0;
     // --callout: rgb(227, 107, 167);
-
-    //Title Text Colors
-    &:is(
-        [data-callout-metadata~="color-blue"], 
-        [data-callout-metadata~="c-blue"],
-        [data-callout-metadata~="background-color-blue"], 
-        [data-callout-metadata~="bg-c-blue"]
-    ) .callout-title { --callout-color: var(--callout-blue); }
-    &:is(
-        [data-callout-metadata~="color-green"], 
-        [data-callout-metadata~="c-green"],
-        [data-callout-metadata~="background-color-green"], 
-        [data-callout-metadata~="bg-c-green"]
-    ) .callout-title { --callout-color: var(--callout-green); }
-
-    &:is(
-        [data-callout-metadata~="color-orange"], 
-        [data-callout-metadata~="c-orange"],
-        [data-callout-metadata~="background-color-orange"], 
-        [data-callout-metadata~="bg-c-orange"]
-    ) .callout-title { --callout-color: var(--callout-orange); }
-
-    &:is(
-        [data-callout-metadata~="color-red"], 
-        [data-callout-metadata~="c-red"],
-        [data-callout-metadata~="background-color-red"],
-        [data-callout-metadata~="bg-c-red"]
-    ) .callout-title { --callout-color: var(--callout-red); }
-
-    &:is(
-        [data-callout-metadata~="color-purple"], 
-        [data-callout-metadata~="c-purple"],
-        [data-callout-metadata~="background-color-purple"],
-        [data-callout-metadata~="bg-c-purple"]
-    ) .callout-title { --callout-color: var(--callout-purple); }
-
-    &:is(
-        [data-callout-metadata~="color-gray"], 
-        [data-callout-metadata~="c-gray"],
-        [data-callout-metadata~="background-color-gray"],
-        [data-callout-metadata~="bg-c-gray"]
-    ) .callout-title { --callout-color: var(--callout-gray); }
-    &:is(
-        [data-callout-metadata~="color-yellow"], 
-        [data-callout-metadata~="c-yellow"],
-        [data-callout-metadata~="background-color-yellow"],
-        [data-callout-metadata~="bg-c-yellow"]
-    ) .callout-title { --callout-color: var(--callout-yellow); }
-    &:is(
-        [data-callout-metadata~="color-pink"], 
-        [data-callout-metadata~="c-pink"],
-        [data-callout-metadata~="background-color-pink"],
-        [data-callout-metadata~="bg-c-pink"]
-    ) .callout-title { --callout-color: var(--callout-pink); }
-    &:is(
-        [data-callout-metadata~="color-brown"], 
-        [data-callout-metadata~="c-brown"],
-        [data-callout-metadata~="background-color-brown"],
-        [data-callout-metadata~="bg-c-brown"]
-    ) .callout-title { --callout-color: var(--callout-brown); }
-    &:is(
-        [data-callout-metadata~="color-black"], 
-        [data-callout-metadata~="bg-black"],
-        [data-callout-metadata~="background-color-black"],
-        [data-callout-metadata~="bg-c-black"]
-    ) .callout-title { --callout-color: var(--callout-black) }
-    &:is(
-        [data-callout-metadata~="color-"], [data-callout-metadata~="c-"]
-    ) { --callout-color: var(--callout); }
-
-
-    //Background Colors
-    &:is(
-        [data-callout-metadata~="background-blue"], 
-        [data-callout-metadata~="bg-blue"],
-        [data-callout-metadata~="background-color-blue"], 
-        [data-callout-metadata~="bg-c-blue"]
-    ) { background-color: rgba(var(--callout-blue), 10%); }
-    &:is(
-        [data-callout-metadata~="background-green"], 
-        [data-callout-metadata~="bg-green"],
-        [data-callout-metadata~="background-color-green"], 
-        [data-callout-metadata~="bg-c-green"]
-    ) { background-color: rgba(var(--callout-green), 10%); }
-
-    &:is(
-        [data-callout-metadata~="background-orange"], 
-        [data-callout-metadata~="bg-orange"],
-        [data-callout-metadata~="background-color-orange"], 
-        [data-callout-metadata~="bg-c-orange"]
-    ) { background-color: rgba(var(--callout-orange), 10%); }
-
-    &:is(
-        [data-callout-metadata~="background-red"], 
-        [data-callout-metadata~="bg-red"],
-        [data-callout-metadata~="background-color-red"], 
-        [data-callout-metadata~="bg-c-red"]
-    ) { background-color: rgba(var(--callout-red), 10%); }
-
-    &:is(
-        [data-callout-metadata~="background-purple"], 
-        [data-callout-metadata~="bg-purple"],
-        [data-callout-metadata~="background-color-purple"], 
-        [data-callout-metadata~="bg-c-purple"]
-    ) { background-color: rgba(var(--callout-purple), 10%); }
-
-    &:is(
-        [data-callout-metadata~="background-gray"], 
-        [data-callout-metadata~="bg-gray"],
-        [data-callout-metadata~="background-color-gray"], 
-        [data-callout-metadata~="bg-c-gray"]
-    ) { background-color: rgba(var(--callout-gray), 10%); }
-    &:is(
-        [data-callout-metadata~="background-yellow"], 
-        [data-callout-metadata~="bg-yellow"],
-        [data-callout-metadata~="background-color-yellow"], 
-        [data-callout-metadata~="bg-c-yellow"]
-    ) { background-color: rgba(var(--callout-yellow), 10%); }
-    &:is(
-        [data-callout-metadata~="background-pink"], 
-        [data-callout-metadata~="bg-pink"],
-        [data-callout-metadata~="background-color-pink"], 
-        [data-callout-metadata~="bg-c-pink"]
-    ) { background-color: rgba(var(--callout-pink), 10%); }
-    &:is(
-        [data-callout-metadata~="background-brown"], 
-        [data-callout-metadata~="bg-brown"],
-        [data-callout-metadata~="background-color-brown"], 
-        [data-callout-metadata~="bg-c-brown"]
-    ) { background-color: rgba(var(--callout-brown), 10%); }
-    &:is(
-        [data-callout-metadata~="background-black"], 
-        [data-callout-metadata~="bg-black"],
-        [data-callout-metadata~="background-color-black"], 
-        [data-callout-metadata~="bg-c-black"]
-    ) { background-color: rgba(var(--callout-black), 10%); }
-
-
-    //Background & Text
-    //Title Text Colors
-    &:is(
-        [data-callout-metadata~="background-color-blue"], 
-        [data-callout-metadata~="bg-c-blue"]
-    ) { --callout-color: var(--callout-blue); }
-    &:is(
-        [data-callout-metadata~="background-color-green"], 
-        [data-callout-metadata~="bg-c-green"]
-    ) { --callout-color: var(--callout-green); }
-    &:is(
-        [data-callout-metadata~="background-color-orange"], 
-        [data-callout-metadata~="bg-c-orange"]
-    ) { --callout-color: var(--callout-orange); }
-    &:is(
-        [data-callout-metadata~="background-color-red"], 
-        [data-callout-metadata~="bg-c-red"]
-    ) { --callout-color: var(--callout-red); }
-    &:is(
-        [data-callout-metadata~="background-color-purple"], 
-        [data-callout-metadata~="bg-c-purple"]
-    ) { --callout-color: var(--callout-purple); }
-    &:is(
-        [data-callout-metadata~="background-color-gray"], 
-        [data-callout-metadata~="bg-c-gray"]
-    ) { --callout-color: var(--callout-gray); }
-    &:is(
-        [data-callout-metadata~="background-color-yellow"], 
-        [data-callout-metadata~="bg-c-yellow"]
-    ) { --callout-color: var(--callout-yellow); }
-    &:is(
-        [data-callout-metadata~="background-color-pink"], 
-        [data-callout-metadata~="bg-c-pink"]
-    ) { --callout-color: var(--callout-pink); }
-    &:is(
-        [data-callout-metadata~="background-color-brown"], 
-        [data-callout-metadata~="bg-c-brown"]
-    ) { --callout-color: var(--callout-brown); }
-    &:is(
-        [data-callout-metadata~="background-color-black"], 
-        [data-callout-metadata~="bg-c-black"]
-    ) { --callout-color: var(--callout-black); }
 }
 
+$callout-colors: (blue, green, orange, red, purple, gray, yellow, pink, brown, black);
+
+//Title Text Colors
+@each $color in $callout-colors {
+    $title-prefixes: (color-#{$color}, c-#{$color});
+    $bg-prefixes: (background-#{$color}, bg-#{$color});
+    $combined-prefixes: (background-color-#{$color}, bg-c-#{$color});
+
+    $title-prefixes: join($title-prefixes, $combined-prefixes);
+    $bg-prefixes: join($bg-prefixes, $combined-prefixes);
+
+    @include utils.select-by-callout-metadata(3, $title-prefixes...) {
+        & .callout-title {
+            --callout-color: var(--callout-#{$color});
+        }
+    }
+
+    @include utils.select-by-callout-metadata(3, $bg-prefixes...) {
+        // Background Colors
+        background-color: rgba(var(--callout-#{$color}), 10%);
+    }
+
+    @include utils.select-by-callout-metadata(3, $combined-prefixes...) {
+        --callout-color: var(--callout#{$color});
+    }
+}
+
+// For unmatched colors?
+@include utils.select-by-callout-metadata(3, "c-", "color-") {
+    --callout-color: var(--callout);
+}

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-positions.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-positions.scss
@@ -1,26 +1,20 @@
-/*Callout Positioning*/
-:not(.is-live-preview) .callout.callout.callout:is(
-    [data-callout-metadata~="p+l"], 
-    [data-callout-metadata~="left"]
-) { 
-    float: left; 
-    margin: unset;
-    margin-right: 8px;
+@use "utils";
+
+:not(.is-live-preview) {
+    @include utils.select-by-callout-metadata(3, "p+l", "left") {
+        float: left;
+        margin: unset;
+        margin-right: 8px;
+    }
+    @include utils.select-by-callout-metadata(2, "p+r", "right") {
+        float: right;
+        margin: unset;
+        margin-left: 8px;
+    }
 }
-:not(.is-live-preview) .callout.callout:is(
-    [data-callout-metadata~="p+r"], 
-    [data-callout-metadata~="right"]
-) { 
-    float: right;
-    margin: unset;
-    margin-left: 8px;
-}
-.callout.callout.callout:is(
-    [data-callout-metadata~="ctr"], 
-    [data-callout-metadata~="center"]
-) {
+
+@include utils.select-by-callout-metadata(3, "ctr", "center") {
     display: block;
     margin: auto;
     float: unset;
 }
-

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-sizing.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-sizing.scss
@@ -1,5 +1,6 @@
+@use "utils";
 
-.callout.callout.callout {
+@include utils.repeat-selector(".callout", 3) {
     --callout-micro: 10%;
     --callout-tiny: 20%;
     --callout-small: 30%;
@@ -8,27 +9,52 @@
     --callout-medium: 60%;
     --callout-med-tall: 80%;
     --callout-tall: 95%;
-
-    &[data-callout-metadata~="wmicro"]   { max-width: unset; width: var(--callout-micro); }
-    &[data-callout-metadata~="wtiny"]    { max-width: unset; width: var(--callout-tiny); }
-    &[data-callout-metadata~="wsmall"]   { max-width: unset; width: var(--callout-small); }
-    &[data-callout-metadata~="ws-med"]   { max-width: unset; width: var(--callout-small-med); }
-    &[data-callout-metadata~="wm-sm"]    { max-width: unset; width: var(--callout-med-small); }
-    &[data-callout-metadata~="wmed"]     { max-width: unset; width: var(--callout-medium); }
-    &[data-callout-metadata~="wm-tl"]    { max-width: unset; width: var(--callout-med-tall); }
-    &[data-callout-metadata~="wtall"]    { max-width: unset; width: var(--callout-tall); }
-    &[data-callout-metadata~="sban"],
-    &[data-callout-metadata~="wfull"]    { width: 100%; float: unset; max-width: 100%; }
-
-    &[data-callout-metadata~="wtiny-c"]    { width: 19%; }
-    &[data-callout-metadata~="wsmall-c"]   { width: 32.4%; }
-    &[data-callout-metadata~="ws-med-c"]   { width: 39%; }
-    &[data-callout-metadata~="wm-sm-c"]    { width: 49%; }
-    &[data-callout-metadata~="wmed-c"]     { width: 59%; }
-    &[data-callout-metadata~="wm-tl-c"]    { width: 79%; }
-    &[data-callout-metadata~="wfit"]       { width: fit-content; max-width: min-content; }
 }
-.callout.callout[data-callout-metadata~="static"] {
+
+$callout-type-to-width: (
+    wmicro: --callout-micro,
+    wtiny: --callout-tiny,
+    wsmall: --callout-small,
+    ws-med: --callout-small-med,
+    wm-sm: --callout-med-small,
+    wmed: --callout-medium,
+    wm-tl: --callout-med-tall,
+    wtall: --callout-tall
+);
+
+@each $type, $width in $callout-type-to-width {
+    @include utils.select-by-callout-metadata(3, #{$type}) {
+        max-width: unset;
+        width: var(#{$width});
+    }
+}
+
+@include utils.select-by-callout-metadata(3, "sban", "wfull") {
+    width: 100%;
+    float: unset;
+    max-width: 100%;
+}
+
+$callout-type-to-width-c: (
+    wtiny-c: 19%,
+    wsmall-c: 32.4%,
+    ws-med-c: 39%,
+    wm-sm-c: 49%,
+    wmed-c: 59%,
+    wm-tl-c: 79%
+);
+
+@each $type, $width in $callout-type-to-width-c {
+    @include utils.select-by-callout-metadata(3, #{$type}) {
+        width: #{$width};
+    }
+}
+
+@include utils.select-by-callout-metadata(3, "wfit") {
+    width: fit-content;
+    max-width: min-content;
+}
+@include utils.select-by-callout-metadata(2, "static") {
     --callout-micro: 50px;
     --callout-tiny: 100px;
     --callout-small: 200px;
@@ -39,20 +65,14 @@
     --callout-tall: 700px;
 }
 
+$padding-type-to-value: (
+    (content-padding-small, c-p-sm): 6px,
+    (content-padding-medium, c-p-med): 12px,
+    (content-padding-large, c-p-lg): 24px
+);
 
-//Padding Sizing
-.callout.callout:is(
-    [data-callout-metadata~="content-padding-small"],
-    [data-callout-metadata~="c-p-sm"]
-) { --callout-content-padding: 6px; }
-
-.callout.callout:is(
-    [data-callout-metadata~="content-padding-medium"],
-    [data-callout-metadata~="c-p-med"]
-) { --callout-content-padding: 12px; }
-
-.callout.callout:is(
-    [data-callout-metadata~="content-padding-large"],
-    [data-callout-metadata~="c-p-lg"]
-) { --callout-content-padding: 24px; }
-
+@each $padding-type, $padding-value in $padding-type-to-value {
+    @include utils.select-by-callout-metadata(2, $padding-type...) {
+        padding: $padding-value;
+    }
+}

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-styling.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-styling.scss
@@ -1,39 +1,34 @@
-.callout-original .callout,
-.callout:is(
-    [data-callout-metadata~='callout-original'], 
-    [data-callout-metadata~='co-o']
-) {
+@use "utils";
+%callout-original {
     --callout-padding: 0;
     --callout-title-padding: 10px 15px;
     --callout-content-padding: 5px 15px;
     --callout-border-opacity: 1;
     --callout-margin: 5px 5px 5px 0;
     --callout-border-width: 0 0 0 3px;
-    
     background-color: var(--note, var(--background-primary));
     box-shadow: var(--shadow-m);
     margin: var(--callout-margin);
-
     & .callout-title {
-        background: rgba(var(--callout-color), .1);
+        background: rgba(var(--callout-color), 0.1);
     }
 }
+.callout-original .callout {
+    @extend %callout-original;
+}
 
-.callout-block .callout,
-.callout:is(
-    [data-callout-metadata~='callout-block'], 
-    [data-callout-metadata~='co-block']
-) {
+@include utils.select-by-callout-metadata(1, "callout-original", "co-o") {
+    @extend %callout-original;
+}
 
+%callout-block {
     --callout-padding: 0;
     --callout-content-padding: 0 10px;
-
     --callout-title-padding: 6px 10px;
     --callout-title-background: var(--callout-color);
-    --callout-border-opacity: .5;
-
-    & .callout-title { 
-        background-color: rgba(var(--callout-title-background, var(--callout-color)), .2); 
+    --callout-border-opacity: 0.5;
+    & .callout-title {
+        background-color: rgba(var(--callout-title-background, var(--callout-color)), 0.2);
     }
     // & .callout-title-inner { color: var(--text-dl); }
 
@@ -41,41 +36,59 @@
         border-bottom: 1px solid rgba(var(--callout-color), var(--callout-border-opacity));
     }
 }
+.callout-block .callout {
+    @extend %callout-block;
+}
 
-.callout-side-icon .callout,
-.callout:is(
-    [data-callout-metadata~='callout-side-icon'], 
-    [data-callout-metadata~='co-si']
-) {
+@include utils.select-by-callout-metadata(1, "callout-block", "co-block") {
+    @extend %callout-block;
+}
+
+%callout-side-icon {
     --callout-title-padding: 0 0 0 20px;
     --callout-title-background: transparent;
     --callout-border-width: 0;
-
     display: flex;
     flex-direction: row;
     align-items: center;
-    & .callout-title-inner { display: none; }
+    & .callout-title-inner {
+        display: none;
+    }
 }
 
-.callout-alternate-line .callout,
-.callout.callout[data-callout-metadata~="alt-line"] {
+.callout-side-icon .callout {
+    @extend %callout-side-icon;
+}
+
+@include utils.select-by-callout-metadata(1, "callout-side-icon", "co-si") {
+    @extend %callout-side-icon;
+}
+
+%callout-alternate-line {
     border: 0;
     background-color: transparent;
     --callout-padding: 0;
     --callout-title-padding: 5px 10px;
     --callout-content-padding: 0px 10px 10px;
-
     & .callout-title {
-        background: transparent; 
+        background: transparent;
         border-bottom: 2px solid var(--table, var(--background-modifier-border));
-        // border-bottom: 2px solid rgb(var(--callout-color), 0.5);
-        // padding: 5px 0;
     }
-    & .callout-fold { color: rgb(var(--callout-color)); }
+    & .callout-fold {
+        color: rgb(var(--callout-color));
+    }
     & .callout-content.callout-content {
         border: 0;
         border-bottom: 1px solid rgba(var(--callout-color), 0.5);
     }
+}
+
+.callout-alternate-line .callout {
+    @extend %callout-alternate-line;
+}
+
+@include utils.select-by-callout-metadata(1, "callout-alternate-line", "alt-line") {
+    @extend %callout-alternate-line;
 }
 
 // .callout-outline .callout,

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-text-adj.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-text-adj.scss
@@ -1,47 +1,40 @@
+@use "utils";
 
-// Align Callout Content Text
-.callout.callout:is(
-    [data-callout-metadata~="txt-l"],
-    [data-callout-metadata~="text-left"]
-) > .callout-content > * {
-    text-align: left;
-}
-.callout.callout:is(
-    [data-callout-metadata~="txt-r"],
-    [data-callout-metadata~="text-right"]
-) > .callout-content {
-    text-align: right;
-}
-.callout.callout:is(
-    [data-callout-metadata~="txt-c"],
-    [data-callout-metadata~="text-center"]
-) > .callout-content {
-    text-align: center;
+@include utils.select-by-callout-metadata(2, "txt-l", "text-left") {
+    & > .callout-content > * {
+        text-align: left;
+    }
 }
 
+@include utils.select-by-callout-metadata(2, "txt-r", "text-right") {
+    & > .callout-content {
+        text-align: right;
+    }
+}
 
-// Align Callout Title Text
-.callout.callout:is(
-    [data-callout-metadata~="ttl-c"], 
-    [data-callout-metadata~="title-center"]
-) {
-    & .callout-title { justify-content: center; }
-    
+@include utils.select-by-callout-metadata(2, "txt-c", "text-center") {
+    & > .callout-content {
+        text-align: center;
+    }
+}
+
+@include utils.select-by-callout-metadata(2, "ttl-c", "title-center") {
+    & .callout-title {
+        justify-content: center;
+    }
+
     & .callout-title-inner {
         display: block;
         flex: unset;
     }
 }
 
+@include utils.select-by-callout-metadata(2, "text-small", "txt-s") {
+    & > .callout-content > * {
+        --font-text-size: var(--font-smallest);
+        --tag-size: var(--font-smallest);
+        --table-text-size: var(--font-smallest);
 
-// Text Sizing
-.callout.callout:is(
-    [data-callout-metadata~='text-small'],
-    [data-callout-metadata~='txt-s']
-) > .callout-content > * {
-    --font-text-size: var(--font-smallest);
-    --tag-size: var(--font-smallest);
-    --table-text-size: var(--font-smallest);
-    
-    font-size: var(--font-text-size);
+        font-size: var(--font-text-size);
+    }
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-cards.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-cards.scss
@@ -1,6 +1,6 @@
-
+@use "utils";
 /* Cards */
-.callout[data-callout~="cards"] {
+@include utils.select-by-callout-metadata(1, "cards") {
     --callout-color: transparent;
     --callout-icon: layout-dashboard;
     --callout-padding: 0;
@@ -12,13 +12,15 @@
     box-shadow: none;
     border: 0;
     width: auto;
-    
-    & > .callout-title { display: none; }
+
+    & > .callout-title {
+        display: none;
+    }
     & > .callout-content {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         grid-gap: 5px;
-        
+
         border-radius: 0;
         padding-inline-start: 0px;
         padding: 0;
@@ -28,32 +30,34 @@
         margin-block-end: 0;
         padding: 0;
     }
-    
-    &:not([data-callout-metadata~='nstr'], [data-callout-metadata~='no-strong']) strong {
+
+    &:not([data-callout-metadata~="nstr"], [data-callout-metadata~="no-strong"]) strong {
         display: block;
         text-align: center;
         margin: auto;
         background-color: var(--outer-bar, var(--background-secondary));
     }
-    & br { display: none; }
+    & br {
+        display: none;
+    }
 
-    
     // Flex
-    &[data-callout-metadata~="flex"] > .callout-content, 
-    &[data-callout-metadata~="flex"] .dataview.table-view-table tbody
-    {
-        gap: unset;
-        grid-template-columns: none;
+    &[data-callout-metadata~="flex"] {
+        &,
+        & .dataview.table-view-table tbody {
+            gap: unset;
+            grid-template-columns: none;
 
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
 
-        // Sub Callout Sizing
-        & .callout {
-            flex: 1 1 250px;
-            margin: 5px;
-            //background: transparent;
+            // Sub Callout Sizing
+            & .callout {
+                flex: 1 1 250px;
+                margin: 5px;
+                //background: transparent;
+            }
         }
     }
 
@@ -69,10 +73,13 @@
             display: unset;
             grid-template-columns: unset;
         }
-        & br { display: block; }
-        
+        & br {
+            display: block;
+        }
 
-        & .block-language-dataview { padding: 5px; }
+        & .block-language-dataview {
+            padding: 5px;
+        }
         & .dataview.table-view-table {
             display: grid;
             margin-block-start: 0;
@@ -84,7 +91,9 @@
                 padding: 0;
             }
             // Hide Background in dv Table
-            & strong { background: transparent; }
+            & strong {
+                background: transparent;
+            }
         }
         // Restyle Table Headers
         & .table-view-thead {
@@ -92,7 +101,9 @@
                 border: 0;
                 background-color: transparent;
             }
-            & tr { display: none; }
+            & tr {
+                display: none;
+            }
         }
 
         // Display cells as grid
@@ -101,7 +112,7 @@
             grid-template-columns: repeat(3, 1fr);
             grid-gap: 10px;
 
-            & tr { 
+            & tr {
                 display: grid;
                 align-content: flex-start;
                 margin: 0;
@@ -113,30 +124,42 @@
                 box-shadow: var(--shadow-ml, var(--input-shadow));
             }
         }
-        &[data-callout-metadata~="txt-c"] .dataview td { text-align: center; }
-
-
-        //Image Sizing
-        & img:not(.link-favicon) { 
-            width: 100%; 
-            object-fit: cover 
+        &[data-callout-metadata~="txt-c"] .dataview td {
+            text-align: center;
         }
 
-        &[data-callout-metadata~="img-micro"]       img { height: var(--micro);     }
-        &[data-callout-metadata~="img-tiny"]        img { height: var(--tiny);      }
-        &[data-callout-metadata~="img-small"]       img { height: var(--small);     }
-        &[data-callout-metadata~="img-small-med"]   img { height: var(--small-med); }
-        &[data-callout-metadata~="img-med-small"]   img { height: var(--med-small); }
-        &[data-callout-metadata~="img-medium"]      img { height: var(--medium);    }
-        &[data-callout-metadata~="img-med-tall"]    img { height: var(--med-tall);  }
-        &[data-callout-metadata~="img-tall"]        img { height: var(--tall);      }
-    }
+        //Image Sizing
+        & img:not(.link-favicon) {
+            width: 100%;
+            object-fit: cover;
+        }
 
+        $sizes: (
+            micro: --micro,
+            tiny: --tiny,
+            small: --small,
+            small-med: --small-med,
+            med-small: --med-small,
+            medium: --medium,
+            med-tall: --med-tall,
+            tall: --tall
+        );
+
+        @each $size, $var in $sizes {
+            &[data-callout-metadata~="img-#{$size}"] img {
+                height: var($var);
+            }
+        }
+    }
 
     //List
     &[data-callout-metadata~="dvl"] {
-        & .callout-content { display: block; }
-        & br { display: unset; }
+        & .callout-content {
+            display: block;
+        }
+        & br {
+            display: unset;
+        }
 
         & .block-language-dataviewjs .dataview-result-list-li,
         & .list-view-ul li {
@@ -145,30 +168,35 @@
             box-shadow: var(--shadow-s, var(--input-shadow));
             margin-bottom: 5px;
         }
-        & .dataview.list-view-ul li::before { margin-left: -27px; }
-        & ul { padding-inline-start: unset; }
-    } 
-
+        & .dataview.list-view-ul li::before {
+            margin-left: -27px;
+        }
+        & ul {
+            padding-inline-start: unset;
+        }
+    }
 
     // Columns
-    @for $i from 1 through  9 {
-        &[data-callout-metadata~="#{$i}"] :is(
-            .dataview.dataview.table-view-table tbody, 
-            .callout-content.callout-content
-        ) { grid-template-columns: repeat($i, 1fr); }
+    @for $i from 1 through 9 {
+        &[data-callout-metadata~="#{$i}"]
+            :is(.dataview.dataview.table-view-table tbody, .callout-content.callout-content) {
+            grid-template-columns: repeat($i, 1fr);
+        }
     }
 }
 
-
 // Sizing Fixes for Note/Device sizes
-.view-content > div:is(.markdown-source-view, .markdown-reading-view) > div
-{ container: note / inline-size; }
+.view-content > div:is(.markdown-source-view, .markdown-reading-view) > div {
+    container: note / inline-size;
+}
 
 @container note (max-width: 700px) {
-    .callout[data-callout~=cards][data-callout-metadata~=dataview] .dataview.table-view-table tbody 
-    { grid-template-columns: repeat(2, 1fr); }
+    .callout[data-callout~="cards"][data-callout-metadata~="dataview"] .dataview.table-view-table tbody {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 @container note (max-width: 400px) {
-    .callout[data-callout~=cards][data-callout-metadata~=dataview] .dataview.table-view-table tbody 
-    { grid-template-columns: repeat(1, 1fr); }
+    .callout[data-callout~="cards"][data-callout-metadata~="dataview"] .dataview.table-view-table tbody {
+        grid-template-columns: repeat(1, 1fr);
+    }
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-checks.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-checks.scss
@@ -1,30 +1,39 @@
-
-.callout[data-callout="checks"] { 
+@use "utils";
+@include utils.select-by-data-callout(1, "checks") {
     --callout-color: unset;
-    --callout-icon: "check-square"; 
+    --callout-icon: "check-square";
     --callout-padding: 0px;
-    
+
     --root-list-spacing: 0;
-    
+
     & ul.contains-task-list {
         display: flex;
         flex-direction: row;
         padding-inline-start: 0;
-        
-        & li.task-list-item { margin-right: 5px; }
-        & li p { margin-block-start: 0; }
+
+        & li.task-list-item {
+            margin-right: 5px;
+        }
+        & li p {
+            margin-block-start: 0;
+        }
     }
-    & > .callout-content > ul:not(.contains-task-list) 
-    { padding-inline-start: 0; }
-    
+    & > .callout-content > ul:not(.contains-task-list) {
+        padding-inline-start: 0;
+    }
+
     & ul:not(.contains-task-list) li {
-        & > .list-bullet { display: none; }
-        
+        & > .list-bullet {
+            display: none;
+        }
+
         --bullet: 0;
         --indentation-guide-color: transparent;
         margin-right: 10px;
     }
-    & ul > li .task-list-item-checkbox { margin-inline-start: 0 !important; }
+    & ul > li .task-list-item-checkbox {
+        margin-inline-start: 0 !important;
+    }
     //Tasks plugin override
 }
 

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-columns.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-columns.scss
@@ -1,4 +1,3 @@
-
 /* Columns */
 .callout[data-callout*="column"] {
     --callout-color: var(--text-normal);
@@ -11,8 +10,10 @@
     width: auto;
     padding: 0;
 
-    & > .callout-content .callout-content { border: 0; }
-    
+    & > .callout-content .callout-content {
+        border: 0;
+    }
+
     & > .callout-content {
         display: grid;
         grid-template-columns: repeat(var(--columns), 1fr);
@@ -23,11 +24,9 @@
         border: 0;
         padding: 0;
     }
-    &:is(
-        [data-callout-metadata~="slim-margins"],
-        [data-callout-metadata~="s-mg"]
-    ) > .callout-content 
-    { gap: 2px; }
+    &:is([data-callout-metadata~="slim-margins"], [data-callout-metadata~="s-mg"]) > .callout-content {
+        gap: 2px;
+    }
 
     @for $i from 3 through 9 {
         &[data-callout-metadata~="#{$i}"] .callout-content {
@@ -35,45 +34,52 @@
         }
     }
 
-
     // Flex
     &[data-callout-metadata~="flex"] {
         & > .callout-content {
             // margin-top: 5px;
             // margin-bottom: 5px;
             gap: 5px;
-            
+
             grid-template-columns: none;
 
             display: flex;
             flex-direction: row;
             flex-wrap: wrap;
-            
-            // Sub Callout Sizing
-            & .callout { flex: 1 1 calc(var(--file-line-width) / 2.5); }
-        }
-        &[data-callout-metadata~="3"] > .callout-content .callout 
-        { flex: 1 1 calc(var(--file-line-width) / 3.5); }
 
-        &[data-callout-metadata~="resize"] .callout { 
-            flex: 1 1 auto; 
-            
-            
-            &[data-callout-metadata~="wmicro"] { width: 5%; }
-            &[data-callout-metadata~="wtiny"]  { width: 10%; }
-            &[data-callout-metadata~="wsmall"] { width: 20%; }
-            &[data-callout-metadata~="ws-med"] { width: 30%; }
-            &[data-callout-metadata~="wmed"]   { width: 40%; }
+            // Sub Callout Sizing
+            & .callout {
+                flex: 1 1 calc(var(--file-line-width) / 2.5);
+            }
+        }
+        &[data-callout-metadata~="3"] > .callout-content .callout {
+            flex: 1 1 calc(var(--file-line-width) / 3.5);
+        }
+
+        &[data-callout-metadata~="resize"] .callout {
+            flex: 1 1 auto;
+            $width-type-to-value: (
+                "wmicro": 5%,
+                "wtiny": 10%,
+                "wsmall": 20%,
+                "ws-med": 30%,
+                "wmed": 40%
+            );
+
+            @each $type, $value in $width-type-to-value {
+                &[data-callout-metadata~="#{$type}"] {
+                    width: $value;
+                }
+            }
         }
     }
 
     //Dataview List Columns
     &[data-callout-metadata~="dataview"] {
-        & > .callout-content { 
-            grid-template-columns: unset; 
-            gap: unset; 
+        & > .callout-content {
+            grid-template-columns: unset;
+            gap: unset;
         }
-
 
         & > .callout-content .dataview.list-view-ul {
             columns: var(--columns);
@@ -86,17 +92,21 @@
 
     &[data-callout-metadata~="list-global"] .callout > .callout-content,
     &[data-callout-metadata~="list"] > .callout-content {
-        grid-template-columns: unset; 
+        grid-template-columns: unset;
 
         & > ul {
             columns: var(--columns);
-            
-            & > li { break-inside: avoid; }
-            & .list-bullet::after { position: relative; }
+
+            & > li {
+                break-inside: avoid;
+            }
+            & .list-bullet::after {
+                position: relative;
+            }
         }
     }
     &[data-callout-metadata~="list-x"] > .callout-content {
-        grid-template-columns: unset; 
+        grid-template-columns: unset;
 
         & > ul {
             display: grid;

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-infobox.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-infobox.scss
@@ -1,25 +1,20 @@
+@use "utils";
 
-
-/*Infobox*/
-:is(
-    .is-mobile:not(.is-tablet), 
-    .is-mobile .is-live-preview, 
-    .is-live-preview :not(.markdown-rendered)
-) .callout[data-callout~="infobox"]:not([data-callout-metadata~="mobile"])
-{ 
-    float: unset !important; 
-    max-width: 100%; 
+:is(.is-mobile:not(.is-tablet), .is-mobile .is-live-preview, .is-live-preview :not(.markdown-rendered))
+    .callout[data-callout~="infobox"]:not([data-callout-metadata~="mobile"]) {
+    float: unset !important;
+    max-width: 100%;
     margin: 0 !important;
     width: auto;
 }
-.callout.callout[data-callout~="infobox"] {
+@include utils.select-by-data-callout(2, "infobox") {
     // --callout-color: var(--interactive-accent-rgb);
     --callout-color: var(--note, var(--background-primary));
     --callout-padding: 0;
     --callout-content-padding: 5px;
     --callout-margin: 0 0 0 5px;
     background: var(--note, var(--background-primary));
-    
+
     --h1-border-line-height: 0;
     --h2-border-line-height: 0;
     --h3-border-line-height: 0;
@@ -37,39 +32,53 @@
     // & .image-embed.is-loaded { height: 0; }
 
     //Center collapse Arrow
-    & > .callout-title { 
+    & > .callout-title {
         justify-content: center;
         align-items: center;
-        align-self: center; 
+        align-self: center;
 
-        & > .callout-icon { align-self: center; }
+        & > .callout-icon {
+            align-self: center;
+        }
     }
-    &:not(.is-collapsed) > .callout-title { padding: 0; }
-    & .callout-fold { padding-right: 0; }
+    &:not(.is-collapsed) > .callout-title {
+        padding: 0;
+    }
+    & .callout-fold {
+        padding-right: 0;
+    }
 
     &.is-collapsed .callout-fold {
         border: 1px solid var(--hr, var(--background-modifier-border));
         // padding: 5px 10px;
         border-radius: var(--radius-m);
     }
-    
+
     //Display title collapse arrow on hover only
-    & > .callout-title .callout-title-inner
-    { display: none; }
-    & > .callout-title .callout-icon { height: 0; }
-    
+    & > .callout-title .callout-title-inner {
+        display: none;
+    }
+    & > .callout-title .callout-icon {
+        height: 0;
+    }
+
     // Fixed for export: DO NOT display: none; ON CALLOUT ICON
     &:not(
-        [data-callout-metadata~="show-title"], 
-        [data-callout-metadata~="s-t"],
-        [data-callout-metadata~="show-icon"],
-        [data-callout-metadata~="s-i"]
-    ) .callout-icon svg { width: 0; height: 0; }
+            [data-callout-metadata~="show-title"],
+            [data-callout-metadata~="s-t"],
+            [data-callout-metadata~="show-icon"],
+            [data-callout-metadata~="s-i"]
+        )
+        .callout-icon
+        svg {
+        width: 0;
+        height: 0;
+    }
 
-    //Hide Background Color 
-    &:not(:hover):not(.is-collapsed) .callout-title 
-    { background-color: transparent; }
-    
+    //Hide Background Color
+    &:not(:hover):not(.is-collapsed) .callout-title {
+        background-color: transparent;
+    }
 
     //Show title
     & .callout-content > .callout[data-callout~="infobox"],
@@ -92,12 +101,13 @@
         }
         & .callout-fold {
             margin-top: auto;
-            margin-bottom: auto; 
+            margin-bottom: auto;
         }
 
-        &.is-collapsed .callout-fold { border: 0; }
+        &.is-collapsed .callout-fold {
+            border: 0;
+        }
     }
-    
 
     //Flush content and add border
     & > .callout-content {
@@ -107,7 +117,9 @@
         border-radius: var(--radius-s);
     }
     //Style Tables
-    & table { width: 100%; }
+    & table {
+        width: 100%;
+    }
     & table td {
         white-space: pre-wrap;
         word-wrap: normal;
@@ -118,7 +130,7 @@
         margin-block-end: 0;
         margin: 0;
     }
-    
+
     //Resize Headers
     & .callout-content > :is(h1, h2, h3, h4, h5, h6) {
         font-size: 20px;
@@ -126,17 +138,16 @@
         margin: 0;
         padding: 2px;
         color: var(--text-normal);
-        background: var(--outer-bar, var(--background-secondary)); 
+        background: var(--outer-bar, var(--background-secondary));
     }
-    //Image 
+    //Image
     // & p,
     & .internal-embed,
-    & img
-    { 
+    & img {
         display: block;
         margin: auto;
         padding: auto;
-        text-align: center; 
+        text-align: center;
     }
 
     &[data-callout-metadata][data-callout-metadata][data-callout-metadata~="left"] {
@@ -149,10 +160,9 @@
         float: unset;
         --callout-margin: 5px 0 0 0;
 
-
         & > .callout-title {
             color: var(--text-normal);
-            background: var(--outer-bar, var(--background-secondary)); 
+            background: var(--outer-bar, var(--background-secondary));
             border: 1px solid var(--table, var(--background-modifier-border));
             border-bottom: none;
         }
@@ -163,9 +173,7 @@
     }
 }
 
-
-    
-.callout.callout[data-callout~="infobox"] {
+@include utils.select-by-data-callout(2, "infobox") {
     //Wikipedia Styling
     &[data-callout-metadata~="wikipedia"] table {
         --table-header-color: var(--text, var(--text-normal));
@@ -180,7 +188,9 @@
 
         // & tr td { border-top-color: var(--hr); }
         // & tr td { border-top: 1.1px solid var(--hr); }
-        & tr:last-child { margin-bottom: 2px; }
+        & tr:last-child {
+            margin-bottom: 2px;
+        }
     }
     //Wikiwand Styling
     // &[data-callout-metadata~="colors"] :is(h1, h2, h3, h4, h5, h6) {
@@ -188,27 +198,36 @@
     // }
 }
 
-@media print { .callout[data-callout~="infobox"] { max-width: 400px; } }
+@media print {
+    .callout[data-callout~="infobox"] {
+        max-width: 400px;
+    }
+}
 
 .theme-light .callout[data-callout~="infobox"][data-callout-metadata~="wikipedia"] {
     --th-text: var(--th);
 }
 
-.illusion.illusion .callout[data-callout~="infobox"] 
-{
-    &.is-collapsed.is-collapsed {
-        &[data-callout-metadata~=left] { margin-left: -30px; }
-        &[data-callout-metadata~=right] { margin-right: -30px; }   
-    }
-    
-    & [data-heading] {
-        --illusion-box-shadow: none;
-        --header-shadow: var(--illusion-box-shadow);
-        --h1-shadow: var(--header-shadow);
-        --h2-shadow: var(--header-shadow);
-        --h3-shadow: var(--header-shadow);
-        --h4-shadow: var(--header-shadow);
-        --h5-shadow: var(--header-shadow);
-        --h6-shadow: var(--header-shadow);
+.illusion.illusion {
+    @include utils.select-by-data-callout(1, "infobox") {
+        &.is-collapsed.is-collapsed {
+            &[data-callout-metadata~="left"] {
+                margin-left: -30px;
+            }
+            &[data-callout-metadata~="right"] {
+                margin-right: -30px;
+            }
+        }
+
+        & [data-heading] {
+            --illusion-box-shadow: none;
+            --header-shadow: var(--illusion-box-shadow);
+            --h1-shadow: var(--header-shadow);
+            --h2-shadow: var(--header-shadow);
+            --h3-shadow: var(--header-shadow);
+            --h4-shadow: var(--header-shadow);
+            --h5-shadow: var(--header-shadow);
+            --h6-shadow: var(--header-shadow);
+        }
     }
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-kanban.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-kanban.scss
@@ -1,7 +1,7 @@
-
+@use "utils";
 
 /*Kanban*/
-.callout.callout[data-callout~="kanban"] {
+@include utils.select-by-data-callout(2, "kanban") {
     --callout-color: unset;
     --callout-icon: layout-dashboard;
     --callout-padding: 0;
@@ -9,7 +9,7 @@
     --item-outline: 0 0 0 1px var(--outline, var(--background-modifier-border));
 
     --lane-width: 250px;
-    
+
     //Undo Styling
     background: transparent;
     box-shadow: none;
@@ -22,16 +22,19 @@
         padding: 5px;
         border-radius: var(--radius-s);
     }
-    & .callout-title-inner { flex: unset; }
-    & .callout-content { padding: 0; }
-    
+    & .callout-title-inner {
+        flex: unset;
+    }
+    & .callout-content {
+        padding: 0;
+    }
+
     //Hide List Bullet
     & ul li::marker,
-    & ul li::before, 
+    & ul li::before,
     & .list-bullet,
-    & ul::before, 
-    & :is(ul, ul ul) .list-collapse-indicator
-    {
+    & ul::before,
+    & :is(ul, ul ul) .list-collapse-indicator {
         list-style-type: none;
         color: transparent;
         display: none !important;
@@ -44,18 +47,20 @@
         padding-inline-start: 0;
         text-align: center;
         overflow: auto;
-        
-        &.list-view-ul { margin-inline-start: unset; }
-        
+
+        &.list-view-ul {
+            margin-inline-start: unset;
+        }
+
         //Lane
         & li {
             min-width: var(--lane-width);
             border: 0;
             padding: 5px;
-            
+
             margin: 5px 1px;
             padding-top: 4px;
-            
+
             background: var(--note, var(--background-primary-alt));
             border-radius: var(--radius-s);
             box-shadow: var(--item-outline), var(--shadow-s);
@@ -66,28 +71,34 @@
         flex-direction: column;
         text-align: left;
         overflow: unset;
-        
+
         //List Items
         & li {
             min-width: calc(var(--lane-width) / 2);
             padding: 5px;
-        
+
             box-shadow: var(--item-outline), var(--shadow-s);
             background: var(--code-bg, var(--background-primary));
-            
-            & :is(img, .internal-embed) { margin-bottom: -6px; }
+
+            & :is(img, .internal-embed) {
+                margin-bottom: -6px;
+            }
         }
     }
     //Fix checkboxes
-    & ul.contains-task-list { 
-        // padding-inline-start: 20px; 
-        
+    & ul.contains-task-list {
+        // padding-inline-start: 20px;
+
         & .task-list-item-checkbox {
             margin-inline-start: 0;
         }
     }
-    & .task-list-item-checkbox { cursor: default; }
+    & .task-list-item-checkbox {
+        cursor: default;
+    }
 
     //Fix Spaced Lists
-    & :is(ul, ol) > li p:first-of-type { margin-block-start: 0; }
+    & :is(ul, ol) > li p:first-of-type {
+        margin-block-start: 0;
+    }
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-kith.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-kith.scss
@@ -1,8 +1,8 @@
 .callout[data-callout="kith"] {
     --callout-icon: user;
     --callout-color: 115, 167, 202;
-    
-    border-color: rgba(var(--callout-color), .7);
+
+    border-color: rgba(var(--callout-color), 0.7);
 
     & .callout-title-inner {
         font-weight: unset;
@@ -24,21 +24,42 @@
         }
     }
 
-
     //Types
     &[data-callout-metadata="family"] {
         --callout-icon: users;
     }
-    &[data-callout-metadata="friend"] {
-        --callout-icon: user-check;
-        --callout-color: 115, 202, 144;
+
+    $callout-type-to-color: (
+        "friend": (
+            "color": (
+                115,
+                202,
+                144
+            ),
+            "icon": user-check
+        ),
+        "romantic": (
+            "color": (
+                202,
+                115,
+                180
+            ),
+            "icon": user-plus
+        ),
+        "antagonist": (
+            "color": (
+                241,
+                74,
+                74
+            ),
+            "icon": user-x
+        )
+    );
+
+    @each $type, $props in $callout-type-to-color {
+        &[data-callout-metadata="#{$type}"] {
+            --callout-icon: #{map-get($props, "icon")};
+            --callout-color: #{map-get($props, "color")};
+        }
     }
-    &[data-callout-metadata="romantic"] {
-        --callout-icon: user-plus;
-        --callout-color: 202, 115, 180;
-    }
-    &[data-callout-metadata="antagonist"] {
-        --callout-icon: user-x;
-        --callout-color: 241, 74, 74;
-    } 
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-statblocks.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-statblocks.scss
@@ -1,6 +1,5 @@
-
-
-.callout.callout[data-callout=statblocks] {
+@use "utils";
+@include utils.select-by-data-callout(2, "statblocks") {
     --callout-color: unset;
     --callout-icon: swords;
 
@@ -12,33 +11,36 @@
         --heading-spacing-top: 0;
         --heading-spacing-bottom: 0;
         --p-spacing: 7px;
-    
+
         --bold-color: var(--headers, var(--h1-color));
-        --hr-icon-symbol: '';
+        --hr-icon-symbol: "";
     }
-        
+
     margin: var(--callout-margin);
     min-width: 10ch;
     max-width: 42ch;
     border-top: 5px solid var(--hr, var(--hr-color));
     border-bottom: 5px solid var(--hr, var(--hr-color));
-    box-shadow: 
-        var(--shadow-l), 
+    box-shadow:
+        var(--shadow-l),
         0 0 20px var(--outline, var(--hr-color));
-    
-    
+
     //Element Styling
-    & h1 { width: auto; }
-    & img:not([class]) { 
-        box-shadow: 0 0 0 4px var(--headers, var(--background-modifier-border)); 
+    & h1 {
+        width: auto;
+    }
+    & img:not([class]) {
+        box-shadow: 0 0 0 4px var(--headers, var(--background-modifier-border));
         margin-right: 4px;
     }
 
     & h1::after,
     & h1::before,
-    & > .callout-title { display: none; }
+    & > .callout-title {
+        display: none;
+    }
 
-    & blockquote {         
+    & blockquote {
         --blockquote-border-thickness: 0;
         --blockquote-padding: 5px 0px 2px 0;
         --blockquote-color: var(--soft-text, var(--text-faint));
@@ -48,13 +50,15 @@
         margin-block-end: 0;
     }
 
-    & hr { margin: 12px auto; }
-    
+    & hr {
+        margin: 12px auto;
+    }
+
     & table {
         --table-header-background: transparent;
         --table-header-color: var(--headers, var(--text-faint));
         --table-header-border-color: transparent;
-    
+
         --table-row-alt-background: transparent;
         --table-column-alt-background: transparent;
         --table-border-color: transparent;
@@ -62,29 +66,31 @@
         --table-cell-padding-x: 4px;
         --table-header-padding-y: 1px;
         --table-header-padding-x: 4px;
-    
+
         --table-style-column-header-background: transparent;
         --table-style-column-header-bold-weight: var(--text-weight);
         --table-style-column-header-bold-color: var(--text, var(--text-normal));
-    
+
         margin: 12px auto;
         width: unset;
     }
 
-
     // Alt Styling
-    &[data-callout-metadata~="full"] { max-width: 100%; }
-    
+    &[data-callout-metadata~="full"] {
+        max-width: 100%;
+    }
+
     &[data-callout-metadata~="columns"] {
         max-width: 100%;
-        
+
         --columns: 2;
         @for $i from 1 through 9 {
-            &[data-callout-metadata~="#{$i}"] { --columns: #{$i}; }
+            &[data-callout-metadata~="#{$i}"] {
+                --columns: #{$i};
+            }
         }
 
         & > .callout-content {
-    
             display: grid;
             grid-template-columns: repeat(var(--columns), 1fr);
             gap: 15px;
@@ -92,9 +98,6 @@
             // & > .callout .callout-content { overflow-x: hidden; }
         }
     }
-
-
-
 
     // Game Styling
     //Dungeons & Dragons
@@ -104,6 +107,4 @@
     // ) {
 
     // }
-
 }
-

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-table.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-table.scss
@@ -1,30 +1,33 @@
-
+@use "utils";
 /* Unwrapped Table */
-.callout.callout[data-callout-metadata~="table"],
-.callout.callout[data-callout~="table"] {
-    border: 0;
-    background-color: transparent;
-    --callout-padding: 0;
 
-    & .callout-content {
-        padding: 0;
+@include utils.repeat-selector(".callout", 2) {
+    &[data-callout-metadata~="table"],
+    &[data-callout~="table"] {
         border: 0;
         background-color: transparent;
-        box-shadow: none;
-    }
-    &:not(
-        [data-callout-metadata~="show-title"], 
-        [data-callout-metadata~="s-t"]
-    ) .callout-title { display: none; }
-    
-    & table { 
-        white-space: nowrap; 
-        margin: 0; 
-        margin: auto;
-        overflow-x: scroll;
-        
-        & th,
-        & td
-        { white-space: nowrap; }
+        --callout-padding: 0;
+
+        & .callout-content {
+            padding: 0;
+            border: 0;
+            background-color: transparent;
+            box-shadow: none;
+        }
+        &:not([data-callout-metadata~="show-title"], [data-callout-metadata~="s-t"]) .callout-title {
+            display: none;
+        }
+
+        & table {
+            white-space: nowrap;
+            margin: 0;
+            margin: auto;
+            overflow-x: scroll;
+
+            & th,
+            & td {
+                white-space: nowrap;
+            }
+        }
     }
 }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-timeline.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-timeline.scss
@@ -1,14 +1,14 @@
-
+@use "utils";
 /* Timeline */
-.callout.callout[data-callout~="timeline"] {
-    --callout-icon: 'clock-12';
+@include utils.select-by-data-callout(2, "timeline") {
+    --callout-icon: "clock-12";
     // --callout-color: 209, 220, 226;
     --callout-padding: 0;
     --callout-title-padding: 10px;
     --callout-content-padding: 10px;
     --callout-margin: 0;
     --timeline-shadow: var(--outline, var(--background-modifier-box-shadow));
-    
+
     --micro: 50px;
     --tiny: 100px;
     --small: 200px;
@@ -25,12 +25,12 @@
     border: 0;
     clear: both;
     position: unset !important;
-    
+
     & .callout-title {
         background: rgba(var(--callout-color), 0.35);
         align-content: center;
         align-items: center;
-        
+
         & em {
             font-style: normal;
             display: block;
@@ -39,7 +39,7 @@
             color: rgb(var(--callout-color));
         }
     }
-    
+
     & .callout-icon {
         background-color: var(--note, var(--background-primary));
         transform: scale(1.2);
@@ -51,52 +51,76 @@
     & .callout-content {
         background-color: rgb(var(--callout-color), 0.1);
     }
-    
-    //Side Alignment
-    &[data-callout-metadata~="t-l"] {
-        border-right: 4px solid rgb(var(--callout-color));
-        margin-right: var(--c-timeline);
-        z-index: 0;
 
-        & > .callout-title,
-        & > .callout-content { box-shadow: -4px 4px 0 var(--timeline-shadow); }
+    &[data-callout-metadata~="t-l"] {
+        //Side Alignment
+        & {
+            border-right: 4px solid rgb(var(--callout-color));
+            margin-right: var(--c-timeline);
+            z-index: 0;
+
+            & > .callout-title,
+            & > .callout-content {
+                box-shadow: -4px 4px 0 var(--timeline-shadow);
+            }
+        }
+        //Title/Icon Alignment
+        & > .callout-title {
+            flex-direction: row-reverse;
+            text-align: right;
+            .callout-icon {
+                float: right;
+                position: absolute;
+                margin-right: -20px;
+            }
+        }
     }
     &[data-callout-metadata~="t-r"] {
-        border-left: 4px solid rgb(var(--callout-color));
-        margin-left: var(--c-timeline);
-        
-        & > .callout-title,
-        & > .callout-content 
-        { box-shadow: 4px 4px 0 var(--timeline-shadow); }
+        //Side Alignment
+        & {
+            border-left: 4px solid rgb(var(--callout-color));
+            margin-left: var(--c-timeline);
+            z-index: 0;
+
+            & > .callout-title,
+            & > .callout-content {
+                box-shadow: 4px 4px 0 var(--timeline-shadow);
+            }
+        }
+        //Title/Icon Alignment
+        & > .callout-title .callout-icon {
+            float: left;
+            position: absolute;
+            margin-left: -20px;
+        }
     }
-    
+
     //Title/Icon Alignment
-    &[data-callout-metadata~="t-l"] > .callout-title {
-        flex-direction: row-reverse;
-        text-align: right;
+    &[data-callout-metadata~="t-l"]
+        &[data-callout-metadata~="t-l"]
+        > .callout-title
+        &[data-callout-metadata~="t-r"]
+        > &[data-callout-metadata~="t-1"]
+        .callout-title {
+        margin-top: var(--micro);
     }
-    &[data-callout-metadata~="t-l"] > .callout-title .callout-icon {
-        float: right;
-        position: absolute;
-        margin-right: -20px;
-    }
-    &[data-callout-metadata~="t-r"] > .callout-title .callout-icon {
-        float: left;
-        position: absolute;
-        margin-left: -20px;
-    }
+    $timeline-type-to-margin: (
+        2: --tiny,
+        3: --small,
+        4: --small-med,
+        5: --med-small,
+        6: --medium,
+        7: 350px,
+        8: --med-tall,
+        9: --tall,
+        10: 750px
+    );
 
-    &[data-callout-metadata~="t-1"]  .callout-title {  margin-top: var(--micro); }
-    &[data-callout-metadata~="t-2"]  .callout-title {  margin-top: var(--tiny); }
-    &[data-callout-metadata~="t-3"]  .callout-title {  margin-top: var(--small); }
-    &[data-callout-metadata~="t-4"]  .callout-title {  margin-top: var(--small-med); }
-    &[data-callout-metadata~="t-5"]  .callout-title {  margin-top: var(--med-small); }
-    &[data-callout-metadata~="t-6"]  .callout-title {  margin-top: var(--medium); }
-    &[data-callout-metadata~="t-7"]  .callout-title {  margin-top: 350px; }
-    &[data-callout-metadata~="t-8"]  .callout-title {  margin-top: var(--med-tall); }
-    &[data-callout-metadata~="t-9"]  .callout-title {  margin-top: var(--tall); }
-    &[data-callout-metadata~="t-10"] .callout-title {  margin-top: 750px; }
-
+    @each $type, $margin in $timeline-type-to-margin {
+        &[data-callout-metadata~="t-#{$type}"] .callout-title {
+            margin-top: var($margin);
+        }
+    }
 
     // &[data-callout-metadata~="b-1"] {   padding-bottom: var(--micro); }
     // &[data-callout-metadata~="b-2"] {   padding-bottom: var(--tiny); }

--- a/SCSS/Theme Rewrite/custom-css/callouts/_utils.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_utils.scss
@@ -1,0 +1,65 @@
+/**
+    * @file
+    * Utility mixins for callouts.
+*/
+
+/**
+    * Repeats a selector a given number of times.
+    *
+    * @param {String} $selector - The selector to repeat.
+    * @param {Number} $times - The number of times to repeat the selector.
+    * @return {String} - The repeated selector.
+*/
+@function repeat-selector($selector, $times) {
+    $result: "";
+    @for $i from 1 through $times {
+        $result: #{$result}#{$selector};
+    }
+    @return $result;
+}
+/**
+    * Applies styling to a selector repeated a number of times.
+    *
+    * @param {String} $selector - The selector to repeat.
+    * @param {Number} $times - The number of times to repeat the selector.
+    * @content - The styling to apply to the repeated selector.
+*/
+@mixin repeat-selector($selector, $times) {
+    #{repeat-selector($selector, $times)} {
+        @content;
+    }
+}
+/**
+    * Styles callouts by using a repeated .callout selector and an attribute selector.
+    *
+    * @param {Number} $callout-repeat - The number of times to repeat the callout selector.
+    * @param {String} $attr - The attribute to select by.
+    * @param {String} $values - The value to select. 
+    * @content - The styling to apply to the callouts.
+
+*/
+@mixin style-callouts-by-attr($callout-repeat, $attr, $values...) {
+    $selectors: ();
+    $callout-seq: repeat-selector(".callout", $callout-repeat);
+
+    @each $v in $values {
+        $cur-selector: '[#{$attr}~="#{$v}"]';
+        $selectors: append($selectors, $cur-selector, comma);
+    }
+    $result: "#{$callout-seq}:is(#{$selectors})";
+    #{$result} {
+        @content;
+    }
+}
+
+@mixin select-by-callout-metadata($callout-repeat, $attr-values...) {
+    @include style-callouts-by-attr($callout-repeat, "data-callout-metadata", $attr-values...) {
+        @content;
+    }
+}
+
+@mixin select-by-data-callout($callout-repeat, $callout-types...) {
+    @include style-callouts-by-attr($callout-repeat, "data-callout", $callout-types...) {
+        @content;
+    }
+}


### PR DESCRIPTION
Hi! I wanted to combine your callouts with my own custom CSS. But I needed to understand how they worked, and I ended up refactoring a lot of them using some nifty SCSS features that help avoid repetition.

I only noticed Prettier was on after doing some work, and it killed your formatting. But here it is anyway. Hope you'll find it useful!
## Mixins

### repeat-selector (mixin/function)
This is a mixin and a function. Both repeat a selector (usually `.callout`) N times so you don't have to copy it, and you can easily adjust the specificity.

### select-by-data-callout
This mixin selects using:
1. `.callout` repeated N times using the previous mixin
2. Comma-separated `data-callout` attribute selectors using `:is`.

### select-by-callout-metadata
This mixin selects using:
1. `.callout` repeated N times
2. Comma-separated `data-callout-metadata` attribute selectors using `:is`

## Sections
In most files I used the above mixins to make the code smaller or make it so the specificity is clear. 

There are some files that I made larger changes to.

### Coloring
I replaced the different coloring selectors using some lists and loops. 

### Kith
Replaced the kith type selectors with a map of type to color/icon.

### Timeline
Replaced the `t-N` selectors with a map and a loop.

### Columns
More loops here

### Callout styling
Used some placeholders and `@extends` together with the above mixins.

## Formatting
I use Prettier, and it killed your formatting before I knew what was happening. 
Hi! I wanted to steal parts of your theme for my own, especially the callouts. But I needed to understand how they worked, and I ended up refactoring a lot of them using some nifty SCSS features that help avoid repetition.

## Mixins

### repeat-selector (mixin/function)
This is a mixin and a function. Both repeat a selector (usually `.callout`) N times so you don't have to copy it, and you can easily adjust the specificity.

### select-by-data-callout
This mixin selects using:
1. `.callout` repeated N times using the previous mixin
2. Comma-separated `data-callout` attribute selectors using `:is`.

### select-by-callout-metadata
This mixin selects using:
1. `.callout` repeated N times
2. Comma-separated `data-callout-metadata` attribute selectors using `:is`

## Sections
In most files I used the above mixins to make the code smaller or make it so the specificity is clear. 

There are some files that I made larger changes to.

### Coloring
I replaced the different coloring selectors using some lists and loops. 

### Kith
Replaced the kith type selectors with a map of type to color/icon.

### Timeline
Replaced the `t-N` selectors with a map and a loop.

### Columns
More loops here

### Callout styling
Used some placeholders and `@extends` together with the above mixins.