### PR TITLE
[Fix] .tables-wide in live preview

### DIFF
--- a/SCSS/Theme Rewrite/custom-css/tables/_tables-wide.scss
+++ b/SCSS/Theme Rewrite/custom-css/tables/_tables-wide.scss
@@ -1,6 +1,11 @@
 .tables-wide,
 .t-w
-{ 
-    & .cm-table-widget.markdown-rendered .table-wrapper,
+{
     & table { width: 100%; } 
+}
+
+.tables-wide,
+.t-w
+{ 
+    & .cm-table-widget.markdown-rendered .table-wrapper { min-width: 100%; } 
 }

--- a/theme.css
+++ b/theme.css
@@ -11004,10 +11004,14 @@ iframe {
   margin-right: auto;
 }
 
-.tables-wide .cm-table-widget.markdown-rendered .table-wrapper, .tables-wide table,
-.t-w .cm-table-widget.markdown-rendered .table-wrapper,
+.tables-wide table,
 .t-w table {
   width: 100%;
+}
+
+.tables-wide .cm-table-widget.markdown-rendered .table-wrapper
+.t-w .cm-table-widget.markdown-rendered .table-wrapper {
+  min-width: 100%;
 }
 
 .tables-no-alt-background.tables-no-alt-background,


### PR DESCRIPTION
Hi!

Someone noticed an issue with the tables-wide class in live preview so I made a fix for it.

When the table is not overflowing, the "Add column after" in live preview is working just fine.
![image](https://github.com/user-attachments/assets/296ccb6b-b3e8-41a5-b0f2-684d68e8bb58)

But if the table overflows and requires a scrollbar, the button sticks to the right side of the wrapper which is fixed at 100% and no longer `fit-content`. This makes the button appear in the middle of the table and move with the scrolling.
![image](https://github.com/user-attachments/assets/aa705542-eea6-4126-a4cb-87c68ebd9143)

For the live preview, I would use the `min-width` property instead, so that the actual width of the table stays `fit-content` and the button sticks to the end of the table.
![image](https://github.com/user-attachments/assets/646a0f83-ceff-4756-a79e-c6e0ba032a3b)


But maybe you would rather have the table not overflow and then the wrapping property of the text would need to be changed. That would fix it too I think. In that case, just consider this PR as an issue instead :)

Thanks for the amazing work you did!