### PR TITLE
Fix timeline center line with rounded styling enabled

### DIFF
--- a/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-timeline.scss
+++ b/SCSS/Theme Rewrite/custom-css/callouts/_callout-type-timeline.scss
@@ -57,6 +57,8 @@
     //Side Alignment
     &[data-callout-metadata~="t-l"] {
         border-right: 4px solid var(--timeline-border);
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
         margin-right: var(--c-timeline);
         z-index: 0;
 
@@ -65,6 +67,8 @@
     }
     &[data-callout-metadata~="t-r"] {
         border-left: 4px solid var(--timeline-border);
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
         margin-left: var(--c-timeline);
         
         & > .callout-title,


### PR DESCRIPTION
When roundness isn't 0, the timeline border ends up rounded as well. This shouldn't be applied to the center line, as it creates gaps. Forcing roundness to 0 in the relevant places seems to fix it.