### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/SCSS/ITS Theme/Custom CSS/_CCSS-SlRvb - Callouts.scss
+++ b/SCSS/ITS Theme/Custom CSS/_CCSS-SlRvb - Callouts.scss
@@ -161,14 +161,14 @@ body .callout.callout.callout:is([data-callout-metadata~="nmg"], [data-callout-m
 
 // Callout Coloring
 .callout.callout.callout {
-    --callout-blue: 82, 139, 212;
-    --callout-green: 86, 179, 117;
-    --callout-orange: 230, 129, 63;
-    --callout-red: 193, 67, 67;
-    --callout-purple: 153, 97, 218;
-    --callout-gray: 166, 189, 197;
-    --callout-yellow: 208, 181, 48;
-    --callout-pink: 227, 107, 167;
+    --callout-blue: rgb(82, 139, 212);
+    --callout-green: rgb(86, 179, 117);
+    --callout-orange: rgb(230, 129, 63);
+    --callout-red: rgb(193, 67, 67);
+    --callout-purple: rgb(153, 97, 218);
+    --callout-gray: rgb(166, 189, 197);
+    --callout-yellow: rgb(208, 181, 48);
+    --callout-pink: rgb(227, 107, 167);
     // --callout: rgb(227, 107, 167);
 
     //Title Text Colors
@@ -208,32 +208,32 @@ body .callout.callout.callout:is([data-callout-metadata~="nmg"], [data-callout-m
     //Background Colors
     &:is(
         [data-callout-metadata~="background-blue"], [data-callout-metadata~="bg-blue"],[data-callout-metadata~="background-color-blue"], [data-callout-metadata~="bg-c-blue"]
-    ) { background-color: rgba(var(--callout-blue), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-blue) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-green"], [data-callout-metadata~="bg-green"],[data-callout-metadata~="background-color-green"], [data-callout-metadata~="bg-c-green"]
-    ) { background-color: rgba(var(--callout-green), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-green) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-orange"], [data-callout-metadata~="bg-orange"],[data-callout-metadata~="background-color-orange"], [data-callout-metadata~="bg-c-orange"]
-    ) { background-color: rgba(var(--callout-orange), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-orange) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-red"], [data-callout-metadata~="bg-red"],[data-callout-metadata~="background-color-red"], [data-callout-metadata~="bg-c-red"]
-    ) { background-color: rgba(var(--callout-red), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-red) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-purple"], [data-callout-metadata~="bg-purple"],[data-callout-metadata~="background-color-purple"], [data-callout-metadata~="bg-c-purple"]
-    ) { background-color: rgba(var(--callout-purple), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-purple) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-gray"], [data-callout-metadata~="bg-gray"],[data-callout-metadata~="background-color-gray"], [data-callout-metadata~="bg-c-gray"]
-    ) { background-color: rgba(var(--callout-gray), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-gray) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-yellow"], [data-callout-metadata~="bg-yellow"],[data-callout-metadata~="background-color-yellow"], [data-callout-metadata~="bg-c-yellow"]
-    ) { background-color: rgba(var(--callout-yellow), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-yellow) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-pink"], [data-callout-metadata~="bg-pink"],[data-callout-metadata~="background-color-pink"], [data-callout-metadata~="bg-c-pink"]
-    ) { background-color: rgba(var(--callout-pink), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-pink) 10%, transparent); }
 }
 
 
@@ -248,13 +248,13 @@ body {
 /* Minimalist Style */ 
 .alt-co .callout.callout,
 .callout[data-callout-metadata~="alt-co"] {
-    background: rgba(var(--callout-color), 0.1); 
+    background: color-mix(in srgb, var(--callout-color) 10%, transparent); 
     border: 0;
     margin-left: 40px;
     margin-right: 40px;
     border-radius: var(--radius, var(--co-radius));
     box-shadow: 
-        1px 1px 0 rgba(var(--callout-color), 0.2);
+        1px 1px 0 color-mix(in srgb, var(--callout-color) 20%, transparent);
 
     & p:first-child {
         margin-block-start: 5px;
@@ -270,13 +270,13 @@ body {
     & .callout-title {
         background: transparent; 
         border-bottom: 2px solid var(--table, var(--background-modifier-border));
-        // border-bottom: 2px solid rgb(var(--callout-color), 0.5);
+        // border-bottom: 2px solid color-mix(in srgb, var(--callout-color) 50%, transparent);
         padding: 5px 0;
     }
-    & .callout-fold { color: rgb(var(--callout-color)); }
+    & .callout-fold { color: var(--callout-color); }
     & .callout-content.callout-content {
         border: 0;
-        border-bottom: 1px solid rgba(var(--callout-color), 0.5);
+        border-bottom: 1px solid color-mix(in srgb, var(--callout-color) 50%, transparent);
     }
 }
 //Inspired by Davey
@@ -581,7 +581,7 @@ body {
 
 /* Recite */
 .callout.callout[data-callout="recite"] {
-    --callout-color: 193, 67, 67;
+    --callout-color: rgb(193, 67, 67);
     --callout-icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path stroke="none" fill="none" d="M0 0h24v24H0z"/><path d="M6.455 19L2 22.5V4a1 1 0 0 1 1-1h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H6.455z"/></svg>';
 
     padding: 10px;
@@ -601,7 +601,7 @@ body {
         padding: 0;
         background: transparent;
 
-        color: rgba(var(--callout-color), 1);
+        color: color-mix(in srgb, var(--callout-color) 100%, transparent);
         justify-content: center;
     }
     &[data-callout-metadata*="bg-"]:not([data-callout-metadata*="bg-c"]) .callout-title { color: var(--text-normal); }
@@ -618,7 +618,7 @@ body {
 /* Metadata */
 .callout.callout[data-callout~="Metadata" i] {
     --callout-icon: layers;
-    --callout-color: 82, 139, 212;
+    --callout-color: rgb(82, 139, 212);
 
     // margin: 0;
     border-width: 2px;
@@ -632,10 +632,10 @@ body {
         justify-content: center; 
     }
     // & .callout-icon { padding-bottom: 6px;}
-    & .callout-fold { color: rgb(var(--callout-color)) }
+    & .callout-fold { color: var(--callout-color) }
     & .callout-title-inner { 
         flex: unset;
-        color: rgb(var(--callout-color)); 
+        color: var(--callout-color); 
     }
     // Content
     & .callout-content { 
@@ -643,9 +643,9 @@ body {
         padding-top: 0px; 
     }
     // Fields
-    & .callout-content strong { color: rgb(var(--callout-color)) }
+    & .callout-content strong { color: var(--callout-color) }
     & .dataview.inline-field-key {
-        background: rgb(var(--callout-color));
+        background: var(--callout-color);
         color: var(--text-on-accent);
         font-weight: 900;
     }
@@ -655,7 +655,7 @@ body {
     }
     
     // Table
-    & table th { background-color: var(--aside-bg, rgba(var(--callout-color), 0.5)); }
+    & table th { background-color: var(--aside-bg, color-mix(in srgb, var(--callout-color) 50%, transparent)); }
     & table { 
         --tbl-td-h: 0;
         --tbl-td-w: 5px;
@@ -1048,7 +1048,7 @@ body {
 /* Timeline */
 .callout.callout[data-callout~="timeline"] {
     --callout-icon: clock-12;
-    // --callout-color: 209, 220, 226;
+    // --callout-color: rgb(209, 220, 226);
     
     --micro: 50px;
     --tiny: 100px;
@@ -1070,7 +1070,7 @@ body {
     
     
     & .callout-title {
-        background: rgb(var(--callout-color), 0.35);
+        background: color-mix(in srgb, var(--callout-color) 35%, transparent);
         align-content: center;
         align-items: center;
         
@@ -1079,7 +1079,7 @@ body {
             display: block;
             font-size: 14px;
             line-height: 12px;
-            color: rgb(var(--callout-color));
+            color: var(--callout-color);
         }
     }
     
@@ -1090,19 +1090,19 @@ body {
     }
 
     & .callout-content {
-        background-color: rgb(var(--callout-color), 0.1);
+        background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
     }
     
     //Side Alignment
     &[data-callout-metadata~="t-l"] {
-        border-right: 4px solid rgb(var(--callout-color));
+        border-right: 4px solid var(--callout-color);
         margin-right: var(--c-timeline);
 
         & > .callout-title,
         & > .callout-content { box-shadow: -4px 4px 0 var(--outline, var(--background-modifier-box-shadow)); }
     }
     &[data-callout-metadata~="t-r"] {
-        border-left: 4px solid rgb(var(--callout-color));
+        border-left: 4px solid var(--callout-color);
         margin-left: var(--c-timeline);
         
         & > .callout-title,

--- a/SCSS/Insiders ITS Theme/Custom CSS/_CCSS-SlRvb - Callouts.scss
+++ b/SCSS/Insiders ITS Theme/Custom CSS/_CCSS-SlRvb - Callouts.scss
@@ -163,14 +163,14 @@ body .callout.callout.callout:is([data-callout-metadata~="nmg"], [data-callout-m
 
 // Callout Coloring
 .callout.callout.callout {
-    --callout-blue: 82, 139, 212;
-    --callout-green: 86, 179, 117;
-    --callout-orange: 230, 129, 63;
-    --callout-red: 193, 67, 67;
-    --callout-purple: 153, 97, 218;
-    --callout-gray: 166, 189, 197;
-    --callout-yellow: 208, 181, 48;
-    --callout-pink: 227, 107, 167;
+    --callout-blue: rgb(82, 139, 212);
+    --callout-green: rgb(86, 179, 117);
+    --callout-orange: rgb(230, 129, 63);
+    --callout-red: rgb(193, 67, 67);
+    --callout-purple: rgb(153, 97, 218);
+    --callout-gray: rgb(166, 189, 197);
+    --callout-yellow: rgb(208, 181, 48);
+    --callout-pink: rgb(227, 107, 167);
     // --callout: rgb(227, 107, 167);
 
     //Title Text Colors
@@ -210,32 +210,32 @@ body .callout.callout.callout:is([data-callout-metadata~="nmg"], [data-callout-m
     //Background Colors
     &:is(
         [data-callout-metadata~="background-blue"], [data-callout-metadata~="bg-blue"],[data-callout-metadata~="background-color-blue"], [data-callout-metadata~="bg-c-blue"]
-    ) { background-color: rgba(var(--callout-blue), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-blue) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-green"], [data-callout-metadata~="bg-green"],[data-callout-metadata~="background-color-green"], [data-callout-metadata~="bg-c-green"]
-    ) { background-color: rgba(var(--callout-green), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-green) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-orange"], [data-callout-metadata~="bg-orange"],[data-callout-metadata~="background-color-orange"], [data-callout-metadata~="bg-c-orange"]
-    ) { background-color: rgba(var(--callout-orange), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-orange) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-red"], [data-callout-metadata~="bg-red"],[data-callout-metadata~="background-color-red"], [data-callout-metadata~="bg-c-red"]
-    ) { background-color: rgba(var(--callout-red), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-red) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-purple"], [data-callout-metadata~="bg-purple"],[data-callout-metadata~="background-color-purple"], [data-callout-metadata~="bg-c-purple"]
-    ) { background-color: rgba(var(--callout-purple), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-purple) 10%, transparent); }
 
     &:is(
         [data-callout-metadata~="background-gray"], [data-callout-metadata~="bg-gray"],[data-callout-metadata~="background-color-gray"], [data-callout-metadata~="bg-c-gray"]
-    ) { background-color: rgba(var(--callout-gray), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-gray) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-yellow"], [data-callout-metadata~="bg-yellow"],[data-callout-metadata~="background-color-yellow"], [data-callout-metadata~="bg-c-yellow"]
-    ) { background-color: rgba(var(--callout-yellow), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-yellow) 10%, transparent); }
     &:is(
         [data-callout-metadata~="background-pink"], [data-callout-metadata~="bg-pink"],[data-callout-metadata~="background-color-pink"], [data-callout-metadata~="bg-c-pink"]
-    ) { background-color: rgba(var(--callout-pink), 10%); }
+    ) { background-color: color-mix(in srgb, var(--callout-pink) 10%, transparent); }
 }
 
 
@@ -250,13 +250,13 @@ body {
 /* Minimalist Style */ 
 .alt-co .callout.callout,
 .callout[data-callout-metadata~="alt-co"] {
-    background: rgba(var(--callout-color), 0.1); 
+    background: color-mix(in srgb, var(--callout-color) 10%, transparent); 
     border: 0;
     margin-left: 40px;
     margin-right: 40px;
     border-radius: var(--radius, var(--co-radius));
     box-shadow: 
-        1px 1px 0 rgba(var(--callout-color), 0.2);
+        1px 1px 0 color-mix(in srgb, var(--callout-color) 20%, transparent);
 
     & p:first-child {
         margin-block-start: 5px;
@@ -272,13 +272,13 @@ body {
     & .callout-title {
         background: transparent; 
         border-bottom: 2px solid var(--table, var(--background-modifier-border));
-        // border-bottom: 2px solid rgb(var(--callout-color), 0.5);
+        // border-bottom: 2px solid color-mix(in srgb, var(--callout-color) 50%, transparent);
         padding: 5px 0;
     }
-    & .callout-fold { color: rgb(var(--callout-color)); }
+    & .callout-fold { color: var(--callout-color); }
     & .callout-content.callout-content {
         border: 0;
-        border-bottom: 1px solid rgba(var(--callout-color), 0.5);
+        border-bottom: 1px solid color-mix(in srgb, var(--callout-color) 50%, transparent);
     }
 }
 //Inspired by Davey
@@ -600,7 +600,7 @@ body {
 
 /* Recite */
 .callout.callout[data-callout="recite"] {
-    --callout-color: 193, 67, 67;
+    --callout-color: rgb(193, 67, 67);
     --callout-icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path stroke="none" fill="none" d="M0 0h24v24H0z"/><path d="M6.455 19L2 22.5V4a1 1 0 0 1 1-1h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H6.455z"/></svg>';
 
     padding: 10px;
@@ -620,7 +620,7 @@ body {
         padding: 0;
         background: transparent;
 
-        color: rgba(var(--callout-color), 1);
+        color: color-mix(in srgb, var(--callout-color) 100%, transparent);
         justify-content: center;
     }
     &[data-callout-metadata*="bg-"]:not([data-callout-metadata*="bg-c"]) .callout-title { color: var(--text-normal); }
@@ -637,7 +637,7 @@ body {
 /* Metadata */
 .callout.callout[data-callout~="Metadata" i] {
     --callout-icon: layers;
-    --callout-color: 82, 139, 212;
+    --callout-color: rgb(82, 139, 212);
 
     // margin: 0;
     border-width: 2px;
@@ -651,10 +651,10 @@ body {
         justify-content: center; 
     }
     // & .callout-icon { padding-bottom: 6px;}
-    & .callout-fold { color: rgb(var(--callout-color)) }
+    & .callout-fold { color: var(--callout-color) }
     & .callout-title-inner { 
         flex: unset;
-        color: rgb(var(--callout-color)); 
+        color: var(--callout-color); 
     }
     // Content
     & .callout-content { 
@@ -662,9 +662,9 @@ body {
         padding-top: 0px; 
     }
     // Fields
-    & .callout-content strong { color: rgb(var(--callout-color)) }
+    & .callout-content strong { color: var(--callout-color) }
     & .dataview.inline-field-key {
-        background: rgb(var(--callout-color));
+        background: var(--callout-color);
         color: var(--text-on-accent);
         font-weight: 900;
     }
@@ -674,7 +674,7 @@ body {
     }
     
     // Table
-    & table th { background-color: var(--aside-bg, rgba(var(--callout-color), 0.5)); }
+    & table th { background-color: var(--aside-bg, color-mix(in srgb, var(--callout-color) 50%, transparent)); }
     & table { 
         --tbl-td-h: 0;
         --tbl-td-w: 5px;
@@ -1067,7 +1067,7 @@ body {
 /* Timeline */
 .callout.callout[data-callout~="timeline"] {
     --callout-icon: 'clock-12';
-    // --callout-color: 209, 220, 226;
+    // --callout-color: rgb(209, 220, 226);
     --callout-padding: 0px;
     --callout-title-padding: 10px;
     --callout-content-padding: 10px;
@@ -1095,7 +1095,7 @@ body {
     
     
     & .callout-title {
-        background: rgb(var(--callout-color), 0.35);
+        background: color-mix(in srgb, var(--callout-color) 35%, transparent);
         align-content: center;
         align-items: center;
         
@@ -1104,7 +1104,7 @@ body {
             display: block;
             font-size: 14px;
             line-height: 12px;
-            color: rgb(var(--callout-color));
+            color: var(--callout-color);
         }
     }
     
@@ -1115,19 +1115,19 @@ body {
     }
 
     & .callout-content {
-        background-color: rgb(var(--callout-color), 0.1);
+        background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
     }
     
     //Side Alignment
     &[data-callout-metadata~="t-l"] > :is(.callout-title, .callout-content) {
-        border-right: 4px solid rgb(var(--callout-color));
+        border-right: 4px solid var(--callout-color);
         margin-right: var(--c-timeline);
 
         & > .callout-title,
         & > .callout-content { box-shadow: -4px 4px 0 var(--outline, var(--background-modifier-box-shadow)); }
     }
     &[data-callout-metadata~="t-r"] > :is(.callout-title, .callout-content) {
-        border-left: 4px solid rgb(var(--callout-color));
+        border-left: 4px solid var(--callout-color);
         margin-left: var(--c-timeline);
         
         & > .callout-title,

--- a/Snippets/S - Callouts.css
+++ b/Snippets/S - Callouts.css
@@ -148,17 +148,17 @@
 /*--Callout Coloring--*/
 .callout.callout.callout {
   --callout-color-opacity: 20%;
-  --callout-blue: 82, 139, 212;
-  --callout-green: 86, 179, 117;
-  --callout-orange: 230, 129, 63;
-  --callout-red: 193, 67, 67;
-  --callout-purple: 153, 97, 218;
-  --callout-gray: 166, 189, 197;
-  --callout-yellow: 208, 181, 48;
-  --callout-pink: 227, 107, 167;
-  --callout-brown: 161, 106, 73;
-  --callout-black: 0, 0, 0;
-  --callout-white: 256, 256, 256;
+  --callout-blue: rgb(82, 139, 212);
+  --callout-green: rgb(86, 179, 117);
+  --callout-orange: rgb(230, 129, 63);
+  --callout-red: rgb(193, 67, 67);
+  --callout-purple: rgb(153, 97, 218);
+  --callout-gray: rgb(166, 189, 197);
+  --callout-yellow: rgb(208, 181, 48);
+  --callout-pink: rgb(227, 107, 167);
+  --callout-brown: rgb(161, 106, 73);
+  --callout-black: rgb(0, 0, 0);
+  --callout-white: rgb(256, 256, 256);
   --callout-plain: transparent;
 }
 .callout.callout.callout:is([data-callout-metadata~=color-blue],
@@ -177,7 +177,7 @@
 [data-callout-metadata~=bg-blue],
 [data-callout-metadata~=background-color-blue],
 [data-callout-metadata~=bg-c-blue]) {
-  --callout-background: rgba(var(--callout-blue), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-blue) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-blue],
@@ -200,7 +200,7 @@
 [data-callout-metadata~=bg-green],
 [data-callout-metadata~=background-color-green],
 [data-callout-metadata~=bg-c-green]) {
-  --callout-background: rgba(var(--callout-green), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-green) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-green],
@@ -223,7 +223,7 @@
 [data-callout-metadata~=bg-orange],
 [data-callout-metadata~=background-color-orange],
 [data-callout-metadata~=bg-c-orange]) {
-  --callout-background: rgba(var(--callout-orange), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-orange) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-orange],
@@ -246,7 +246,7 @@
 [data-callout-metadata~=bg-red],
 [data-callout-metadata~=background-color-red],
 [data-callout-metadata~=bg-c-red]) {
-  --callout-background: rgba(var(--callout-red), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-red) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-red],
@@ -269,7 +269,7 @@
 [data-callout-metadata~=bg-purple],
 [data-callout-metadata~=background-color-purple],
 [data-callout-metadata~=bg-c-purple]) {
-  --callout-background: rgba(var(--callout-purple), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-purple) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-purple],
@@ -292,7 +292,7 @@
 [data-callout-metadata~=bg-gray],
 [data-callout-metadata~=background-color-gray],
 [data-callout-metadata~=bg-c-gray]) {
-  --callout-background: rgba(var(--callout-gray), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-gray) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-gray],
@@ -315,7 +315,7 @@
 [data-callout-metadata~=bg-yellow],
 [data-callout-metadata~=background-color-yellow],
 [data-callout-metadata~=bg-c-yellow]) {
-  --callout-background: rgba(var(--callout-yellow), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-yellow) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-yellow],
@@ -338,7 +338,7 @@
 [data-callout-metadata~=bg-pink],
 [data-callout-metadata~=background-color-pink],
 [data-callout-metadata~=bg-c-pink]) {
-  --callout-background: rgba(var(--callout-pink), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-pink) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-pink],
@@ -361,7 +361,7 @@
 [data-callout-metadata~=bg-brown],
 [data-callout-metadata~=background-color-brown],
 [data-callout-metadata~=bg-c-brown]) {
-  --callout-background: rgba(var(--callout-brown), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-brown) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-brown],
@@ -384,7 +384,7 @@
 [data-callout-metadata~=bg-black],
 [data-callout-metadata~=background-color-black],
 [data-callout-metadata~=bg-c-black]) {
-  --callout-background: rgba(var(--callout-black), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-black) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-black],
@@ -407,7 +407,7 @@
 [data-callout-metadata~=bg-white],
 [data-callout-metadata~=background-color-white],
 [data-callout-metadata~=bg-c-white]) {
-  --callout-background: rgba(var(--callout-white), var(--callout-color-opacity));
+  --callout-background: color-mix(in srgb, var(--callout-white) calc(var(--callout-color-opacity) * 100%), transparent);
   background-color: var(--callout-background);
 }
 .callout.callout.callout:is([data-callout-metadata~=background-color-white],
@@ -1219,7 +1219,7 @@
 
 /* Recite */
 .callout.callout[data-callout=recite] {
-  --callout-color: 193, 67, 67;
+  --callout-color: rgb(193, 67, 67);
   --callout-icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path stroke="none" fill="none" d="M0 0h24v24H0z"/><path d="M6.455 19L2 22.5V4a1 1 0 0 1 1-1h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H6.455z"/></svg>';
   --callout-margin: 10px;
   --callout-padding: 5px 10px 10px 10px;
@@ -1234,7 +1234,7 @@
 .callout.callout[data-callout=recite] .callout-title {
   padding: 0;
   background: transparent;
-  color: rgba(var(--callout-color), 1);
+  color: color-mix(in srgb, var(--callout-color) 100%, transparent);
   justify-content: center;
 }
 .callout.callout[data-callout=recite][data-callout-metadata*=bg-]:not([data-callout-metadata*=bg-c]) .callout-title {
@@ -1320,7 +1320,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i]:not([d
 [data-callout-metadata*=bg-c-],
 [data-callout-metadata*=c-],
 [data-callout-metadata*=color-]) {
-  --callout-color: 82, 139, 212;
+  --callout-color: rgb(82, 139, 212);
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] .callout-title {
   background-color: transparent;
@@ -1328,13 +1328,13 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] .callo
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] .callout-title-inner {
   flex: unset;
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i]:not([data-callout-metadata~=no-strong], [data-callout-metadata~=no-str]) {
-  --bold-color: rgb(var(--callout-color)) ;
+  --bold-color: var(--callout-color) ;
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] .dataview.inline-field-key {
-  background: rgb(var(--callout-color));
+  background: var(--callout-color);
   color: var(--text-on-accent);
   font-weight: 900;
 }
@@ -1343,7 +1343,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] .datav
   background: transparent;
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] table th {
-  background-color: var(--aside-bg, rgba(var(--callout-color), 0.5));
+  background-color: var(--aside-bg, color-mix(in srgb, var(--callout-color) 50%, transparent));
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i] table {
   --tbl-td-h: 0;
@@ -1371,7 +1371,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
 [data-callout-metadata*=bg-c-],
 [data-callout-metadata*=c-],
 [data-callout-metadata*=color-]) {
-  background: rgba(var(--callout-color), var(--callout-color-opacity));
+  background: color-mix(in srgb, var(--callout-color) calc(var(--callout-color-opacity) * 100%), transparent);
 }
 body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-callout-metadata~=i-at].is-collapsible:not(.is-collapsed) {
   display: flex;
@@ -1596,7 +1596,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
   --callout-content-padding: 10px;
   --callout-margin: 0;
   --timeline-shadow: var(--outline, var(--background-modifier-box-shadow));
-  --callout-content-background: var(--callout-background, rgb(var(--callout-color), 0.1));
+  --callout-content-background: var(--callout-background, color-mix(in srgb, var(--callout-color) 10%, transparent));
   --timeline-border: rgb(var(--callout-title, var(--callout-color)));
   --micro: 50px;
   --tiny: 100px;
@@ -1614,7 +1614,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
   position: unset !important;
 }
 .callout.callout[data-callout~=timeline] .callout-title {
-  background: rgba(var(--callout-color), 0.35);
+  background: color-mix(in srgb, var(--callout-color) 35%, transparent);
   align-content: center;
   align-items: center;
 }
@@ -1623,7 +1623,7 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
   display: block;
   font-size: 14px;
   line-height: 12px;
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
 }
 .callout.callout[data-callout~=timeline] .callout-icon {
   background-color: var(--note, var(--background-primary));
@@ -1698,12 +1698,12 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
 
 .callout[data-callout=kith] {
   --callout-icon: user;
-  --callout-color: 115, 167, 202;
-  border-color: rgba(var(--callout-color), 0.7);
+  --callout-color: rgb(115, 167, 202);
+  border-color: color-mix(in srgb, var(--callout-color) 70%, transparent);
 }
 .callout[data-callout=kith] .callout-title-inner {
   font-weight: unset;
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
 }
 .callout[data-callout=kith] .callout-title-inner em {
   display: block;
@@ -1721,15 +1721,15 @@ body:not(.callout-no-metadata) .callout.callout[data-callout~=Metadata i][data-c
 }
 .callout[data-callout=kith][data-callout-metadata=friend] {
   --callout-icon: user-check;
-  --callout-color: 115, 202, 144;
+  --callout-color: rgb(115, 202, 144);
 }
 .callout[data-callout=kith][data-callout-metadata=romantic] {
   --callout-icon: user-plus;
-  --callout-color: 202, 115, 180;
+  --callout-color: rgb(202, 115, 180);
 }
 .callout[data-callout=kith][data-callout-metadata=antagonist] {
   --callout-icon: user-x;
-  --callout-color: 241, 74, 74;
+  --callout-color: rgb(241, 74, 74);
 }
 
 .callout[data-callout=checks] {
@@ -1964,7 +1964,7 @@ body:not(.default-callout-quote, .callout-no-quote) .callout.callout[data-callou
 .callout-original .callout .callout-title,
 .callout:is([data-callout-metadata~=callout-original],
 [data-callout-metadata~=co-o]) .callout-title {
-  background: rgba(var(--callout-color), 0.1);
+  background: color-mix(in srgb, var(--callout-color) 10%, transparent);
 }
 
 .callout-block .callout,
@@ -1984,7 +1984,7 @@ body:not(.default-callout-quote, .callout-no-quote) .callout.callout[data-callou
 .callout-block .callout.is-collapsible:not(.is-collapsed) > .callout-content,
 .callout:is([data-callout-metadata~=callout-block],
 [data-callout-metadata~=co-block]).is-collapsible:not(.is-collapsed) > .callout-content {
-  border-bottom: 1px solid rgba(var(--callout-color), var(--callout-border-opacity));
+  border-bottom: 1px solid color-mix(in srgb, var(--callout-color) calc(var(--callout-border-opacity) * 100%), transparent);
 }
 
 .callout-alternate-line .callout,
@@ -2002,12 +2002,12 @@ body:not(.default-callout-quote, .callout-no-quote) .callout.callout[data-callou
 }
 .callout-alternate-line .callout .callout-fold,
 .callout.callout[data-callout-metadata~=alt-line] .callout-fold {
-  color: rgb(var(--callout-color));
+  color: var(--callout-color);
 }
 .callout-alternate-line .callout .callout-content.callout-content,
 .callout.callout[data-callout-metadata~=alt-line] .callout-content.callout-content {
   border: 0;
-  border-bottom: 1px solid rgba(var(--callout-color), 0.5);
+  border-bottom: 1px solid color-mix(in srgb, var(--callout-color) 50%, transparent);
 }
 
 .callout-bordered .callout:not([data-callout-metadata~=callout-block],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-   "name": "ITS Theme",
-   "version": "1.4.07",
-   "minAppVersion": "0.16.0",
-   "author": "SlRvb",
-   "authorUrl": "https://github.com/SlRvb"
+  "name": "ITS Theme",
+  "version": "1.4.07",
+  "minAppVersion": "1.13.0",
+  "author": "SlRvb",
+  "authorUrl": "https://github.com/SlRvb"
 }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
