### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/SCSS/Theme Rewrite/custom-css/canvas/_canvas-adj.scss
+++ b/SCSS/Theme Rewrite/custom-css/canvas/_canvas-adj.scss
@@ -1,1 +1,1 @@
-.canvas-arrow-text-color .canvas-path-label { color: rgb(var(--canvas-color)); }
+.canvas-arrow-text-color .canvas-path-label { color: var(--canvas-color); }

--- a/SCSS/Theme Rewrite/custom-css/canvas/_canvas-style-cards.scss
+++ b/SCSS/Theme Rewrite/custom-css/canvas/_canvas-style-cards.scss
@@ -7,7 +7,7 @@
         box-shadow: inset 0 0 0 2px var(--outline), var(--shadow-m);
         
         &:hover .canvas-node-content {
-            background-color: rgba(var(--canvas-color), .2);
+            background-color: color-mix(in srgb, var(--canvas-color) 20%, transparent);
         }
     }
 }

--- a/SCSS/Theme Rewrite/custom-css/canvas/_canvas-style-milanote.scss
+++ b/SCSS/Theme Rewrite/custom-css/canvas/_canvas-style-milanote.scss
@@ -11,7 +11,7 @@ body.canvas-milanote.canvas-milanote {
     //Group
     &.canvas-node-group .canvas-node-content { --canvas-color-opacity: 15%; }
     // &.canvas-node-group > .canvas-node-container {
-    //     border: 3px solid rgb(var(--canvas-color));
+    //     border: 3px solid var(--canvas-color);
     //     box-shadow: none;
     // } 
     & .canvas-node-content.markdown-embed:not(.is-loaded) {
@@ -57,13 +57,13 @@ body.canvas-milanote.canvas-milanote {
         box-shadow: var(--canvas-card-shadow-size) var(--canvas-card-shadow-color); 
     }
     // &.is-focused:not(.canvas-node-group) > .canvas-node-container 
-    // { border-color: rgb(var(--canvas-color)); }
+    // { border-color: var(--canvas-color); }
     
     &.is-themed:not(.canvas-node-group) > .canvas-node-container 
     { 
         border-color: transparent;
         box-shadow: 
-        0 -4px 0 -.4px rgb(var(--canvas-color)),
+        0 -4px 0 -.4px var(--canvas-color),
         var(--canvas-card-shadow-size) var(--canvas-card-shadow-color);
     }
 } 

--- a/SCSS/Theme Rewrite/plugins-core/_canvas.scss
+++ b/SCSS/Theme Rewrite/plugins-core/_canvas.scss
@@ -4,10 +4,10 @@ body {
 }
 
 body.theme-dark {
-    --canvas-color: 88, 100, 159;
+    --canvas-color: rgb(88, 100, 159);
 }
 body.theme-light {
-    --canvas-color: 166, 180, 204;
+    --canvas-color: rgb(166, 180, 204);
 }
 
 .canvas-control-group,
@@ -19,7 +19,7 @@ body.theme-light {
 .canvas-card-menu { border: var(--box-border); }
 
 .canvas-node.is-themed .canvas-node-content {
-    background-color: rgba(var(--canvas-color), var(--canvas-color-opacity));
+    background-color: color-mix(in srgb, var(--canvas-color) calc(var(--canvas-color-opacity) * 100%), transparent);
 }
 
 //Embeded Canvas
@@ -34,7 +34,7 @@ body.theme-light {
 } 
 
 .canvas-node-placeholder { line-height: var(--line-height-tight); }
-.canvas-node-connection-point::after { border-color: rgb(var(--canvas-color)); }
+.canvas-node-connection-point::after { border-color: var(--canvas-color); }
 .canvas-path-label { background-color: var(--canvas-background); }
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-   "name": "ITS Theme",
-   "version": "1.4.07",
-   "minAppVersion": "0.16.0",
-   "author": "SlRvb",
-   "authorUrl": "https://github.com/SlRvb"
+  "name": "ITS Theme",
+  "version": "1.4.07",
+  "minAppVersion": "1.13.0",
+  "author": "SlRvb",
+  "authorUrl": "https://github.com/SlRvb"
 }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
